### PR TITLE
SMF POD Crash Fix

### DIFF
--- a/fsm/handler.go
+++ b/fsm/handler.go
@@ -94,12 +94,14 @@ func EmptyEventHandler(event SmEvent, eventData *SmEventData) (smf_context.SMCon
 func HandleStateInitEventPduSessCreate(event SmEvent, eventData *SmEventData) (smf_context.SMContextState, error) {
 	if err := producer.HandlePDUSessionSMContextCreate(eventData.Txn); err != nil {
 		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_failure)
+		var errorMessage string = ""
 		if err != nil {
 			logger.FsmLog.Errorf("error while publishing pdu session create response failure, %v ", err.Error())
+			errorMessage = err.Error()
 		}
 		txn := eventData.Txn.(*transaction.Transaction)
 		txn.Err = err
-		return smf_context.SmStateInit, fmt.Errorf("pdu session create error, %v ", err.Error())
+		return smf_context.SmStateInit, fmt.Errorf("pdu session create error, %v ", errorMessage)
 	}
 
 	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_success)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:

After the migration, the SMF pod experienced a crash while handling unstructured PDU session types. The correct behavior should be to reject the PDU session when an unstructured type is sent, rather than allowing it to cause a crash. This PR fixes the SMF pod crash and ensures that unstructured PDU session types are properly rejected, maintaining stability and correct session management.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#7](https://github.com/5GC-DEV/smf-cdac/issues/7)

**Test Report Added?**:

> /kind TESTED


**Test Report**:
[IOS-MCN-TEST-Report-SMF](https://docs.google.com/spreadsheets/d/1lE52SJlMEJMvY_HhGzkHQ0sUIEviTY71/edit?gid=311112926#gid=311112926)

**Special notes for your reviewer**:
NIL