### PR TITLE
Missing PDU Session Release Reject for Invalid N2-SM ID

### DIFF
--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/nas/nasType"
 	"github.com/omec-project/smf/qos"
+	errors "github.com/omec-project/smf/smferrors"
 )
 
 func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error) {
@@ -175,7 +176,7 @@ func BuildGSMPDUSessionReleaseCommand(smContext *SMContext) ([]byte, error) {
 	pDUSessionReleaseCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionReleaseCommand.SetPDUSessionID(uint8(smContext.PDUSessionID))
 	pDUSessionReleaseCommand.SetPTI(smContext.Pti)
-	// Modified by CDAC TVM
+	// Modification According to the 3GPP TS 24.501, Section 6.3.3 Network-requested PDU session release procedure
 	pDUSessionReleaseCommand.SetCauseValue(0x24)
 	// End of Modification
 
@@ -222,5 +223,21 @@ func BuildGSMPDUSessionReleaseReject(smContext *SMContext) ([]byte, error) {
 	// TODO: fix to real value
 	pDUSessionReleaseReject.SetCauseValue(nasMessage.Cause5GSMRequestRejectedUnspecified)
 
+	return m.PlainNasEncode()
+}
+
+func BuildGSMPDUSessionReleaseRejectWithCause(smContext *SMContext, pduSessionID int32, cause string) ([]byte, error) {
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionReleaseReject)
+	m.GsmHeader.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	m.PDUSessionReleaseReject = nasMessage.NewPDUSessionReleaseReject(0x0)
+	pDUSessionReleaseRejectWithCause := m.PDUSessionReleaseReject
+	pDUSessionReleaseRejectWithCause.SetMessageType(nas.MsgTypePDUSessionReleaseReject)
+	pDUSessionReleaseRejectWithCause.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	pDUSessionReleaseRejectWithCause.SetPDUSessionID(uint8(pduSessionID))
+	pDUSessionReleaseRejectWithCause.SetPTI(smContext.Pti)
+	uint8Cause := errors.ErrorCause[cause]
+	pDUSessionReleaseRejectWithCause.SetCauseValue(uint8Cause)
 	return m.PlainNasEncode()
 }

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -570,7 +570,7 @@ func (smContext *SMContext) isAllowedPDUSessionType(requestedPDUSessionType uint
 		} else {
 			return fmt.Errorf("PduSessionType_ETHERNET is not allowed in DNN[%s] configuration", smContext.Dnn)
 		}
-	// Modification start by CDAC
+	// Modified to fix the Unstructured Session type
 	case models.PduSessionType_UNSTRUCTURED:
 		smContext.SelectedPDUSessionType = nasConvert.ModelsToPDUSessionType(models.PduSessionType_UNSTRUCTURED)
 		return fmt.Errorf("Unstructured PDU Session type")

--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -52,39 +52,57 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 		switch m.GsmHeader.GetMessageType() {
 		case nas.MsgTypePDUSessionReleaseRequest:
 			smContext.SubPduSessLog.Infof("PDUSessionSMContextUpdate, N1 Msg PDU Session Release Request received")
+
+			pduSessIDRelReq := int32(m.PDUSessionReleaseRequest.PDUSessionID.GetPDUSessionID())
+			smContext.SubPduSessLog.Debug("PDU Session ID in Rel Req: ", pduSessIDRelReq)
+			pduSessIDSmCxt := smContext.PDUSessionID
+			smContext.SubPduSessLog.Debug("PDU Session ID in SM Context: ", pduSessIDSmCxt)
+
 			if smContext.SMContextState != context.SmStateActive {
 				// Wait till the state becomes SmStateActive again
 				// TODO: implement sleep wait in concurrent architecture
 				smContext.SubPduSessLog.Infof("PDUSessionSMContextUpdate, SM Context State[%v] should be SmStateActive", smContext.SMContextState.String())
 			}
+			if pduSessIDRelReq == pduSessIDSmCxt {
+				smContext.HandlePDUSessionReleaseRequest(m.PDUSessionReleaseRequest)
+				if buf, err := context.BuildGSMPDUSessionReleaseCommand(smContext); err != nil {
+					smContext.SubPduSessLog.Errorf("PDUSessionSMContextUpdate, build GSM PDUSessionReleaseCommand failed: %+v", err)
+				} else {
+					response.BinaryDataN1SmMessage = buf
+				}
 
-			smContext.HandlePDUSessionReleaseRequest(m.PDUSessionReleaseRequest)
-			if buf, err := context.BuildGSMPDUSessionReleaseCommand(smContext); err != nil {
-				smContext.SubPduSessLog.Errorf("PDUSessionSMContextUpdate, build GSM PDUSessionReleaseCommand failed: %+v", err)
+				response.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseCommand"}
+
+				response.JsonData.N2SmInfo = &models.RefToBinaryData{ContentId: "PDUResourceReleaseCommand"}
+				response.JsonData.N2SmInfoType = models.N2SmInfoType_PDU_RES_REL_CMD
+
+				if buf, err := context.BuildPDUSessionResourceReleaseCommandTransfer(smContext); err != nil {
+					smContext.SubPduSessLog.Errorf("PDUSessionSMContextUpdate, build PDUSessionResourceReleaseCommandTransfer failed: %+v", err)
+				} else {
+					response.BinaryDataN2SmInformation = buf
+				}
+
+				if smContext.Tunnel != nil {
+					smContext.ChangeState(context.SmStatePfcpModify)
+					smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+					// Send release to UPF
+					// releaseTunnel(smContext)
+					pfcpAction.sendPfcpDelete = true
+				} else {
+					smContext.ChangeState(context.SmStateModify)
+					smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				}
 			} else {
-				response.BinaryDataN1SmMessage = buf
-			}
-
-			response.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseCommand"}
-
-			response.JsonData.N2SmInfo = &models.RefToBinaryData{ContentId: "PDUResourceReleaseCommand"}
-			response.JsonData.N2SmInfoType = models.N2SmInfoType_PDU_RES_REL_CMD
-
-			if buf, err := context.BuildPDUSessionResourceReleaseCommandTransfer(smContext); err != nil {
-				smContext.SubPduSessLog.Errorf("PDUSessionSMContextUpdate, build PDUSessionResourceReleaseCommandTransfer failed: %+v", err)
-			} else {
-				response.BinaryDataN2SmInformation = buf
-			}
-
-			if smContext.Tunnel != nil {
-				smContext.ChangeState(context.SmStatePfcpModify)
-				smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
-				// Send release to UPF
-				// releaseTunnel(smContext)
-				pfcpAction.sendPfcpDelete = true
-			} else {
+				smContext.SubPduSessLog.Errorf("Invalid PDU Session ID")
+				if buf, err := context.BuildGSMPDUSessionReleaseRejectWithCause(smContext, pduSessIDRelReq, "InvalidPDUSessionIdentity"); err != nil {
+					smContext.SubPduSessLog.Errorf("PDUSessionSMContextRelease, build GSM PDUSessionReleaseReject failed: %+v", err)
+				} else {
+					response.BinaryDataN1SmMessage = buf
+				}
+				response.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseReject"}
 				smContext.ChangeState(context.SmStateModify)
-				smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				// smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				smContext.SubCtxLog.Infoln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
 			}
 
 		case nas.MsgTypePDUSessionReleaseComplete:

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -182,14 +182,14 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 	establishmentRequest := m.PDUSessionEstablishmentRequest
 
 	smContext.HandlePDUSessionEstablishmentRequest(establishmentRequest)
-	// Modified by cdac
+	// Modified to fix the Unsupported Session types
 	if smContext.SelectedPDUSessionType != nasMessage.PDUSessionTypeIPv4 && smContext.SelectedPDUSessionType != nasMessage.PDUSessionTypeIPv4IPv6 {
 		pduTypeStr := pduSessionTypeToString(smContext.SelectedPDUSessionType)
 		smContext.SubPduSessLog.Errorf("%s PDU Session Not Supported", pduTypeStr)
 		txn.Rsp = smContext.GeneratePDUSessionEstablishmentReject("PDUSessionTypeIPv4OnlyAllowed")
 		return fmt.Errorf("%s PDU Session not supported", pduTypeStr)
 	}
-	// End of CDAC edit
+	// End of modification
 	if err := smContext.PCFSelection(); err != nil {
 		smContext.SubPduSessLog.Errorf("PDUSessionSMContextCreate, send NF Discovery Serving PCF Error[%v]", err)
 		txn.Rsp = smContext.GeneratePDUSessionEstablishmentReject("PCFDiscoveryFailure")

--- a/smferrors/errors.go
+++ b/smferrors/errors.go
@@ -141,4 +141,5 @@ var ErrorCause = map[string]uint8{
 	"ApplySMPolicyFailure":          nasMessage.Cause5GSMRequestRejectedUnspecified,
 	"AMFDiscoveryFailure":           nasMessage.Cause5GSMRequestRejectedUnspecified,
 	"PDUSessionTypeIPv4OnlyAllowed": nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed,
+	"InvalidPDUSessionIdentity":     nasMessage.Cause5GSMInvalidPDUSessionIdentity,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
 If the PDU Session ID to be released which is included in the n2-sm message is invalid, the network should send pdu session release reject. Currently, only the validity of the PDU Session ID included in the UL Nas transport message is considered.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#114](https://github.com/ios-mcn-core/ios-mcn-core/issues/114)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
