### PR TITLE
N2 Handover PFCP modification after Handover notify

### DIFF
--- a/context/ngap_handler.go
+++ b/context/ngap_handler.go
@@ -5,7 +5,6 @@
 package context
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -159,12 +158,11 @@ func HandleHandoverRequestAcknowledgeTransfer(b []byte, ctx *SMContext) (err err
 	}
 	DLNGUUPTNLInformation := handoverRequestAcknowledgeTransfer.DLNGUUPTNLInformation
 	GTPTunnel := DLNGUUPTNLInformation.GTPTunnel
-	TEIDReader := bytes.NewBuffer(GTPTunnel.GTPTEID.Value)
 
-	teid, err := binary.ReadUvarint(TEIDReader)
-	if err != nil {
-		return fmt.Errorf("parse TEID error %s", err.Error())
+	if len(GTPTunnel.GTPTEID.Value) != 4 {
+		return fmt.Errorf("invalid GTP TEID length: %d", len(GTPTunnel.GTPTEID.Value))
 	}
+	teid := binary.BigEndian.Uint32(GTPTunnel.GTPTEID.Value)
 
 	for _, dataPath := range ctx.Tunnel.DataPathPool {
 		if dataPath.Activated {
@@ -173,7 +171,7 @@ func HandleHandoverRequestAcknowledgeTransfer(b []byte, ctx *SMContext) (err err
 				DLPDR.FAR.ForwardingParameters.OuterHeaderCreation = new(OuterHeaderCreation)
 				dlOuterHeaderCreation := DLPDR.FAR.ForwardingParameters.OuterHeaderCreation
 				dlOuterHeaderCreation.OuterHeaderCreationDescription = OuterHeaderCreationGtpUUdpIpv4
-				dlOuterHeaderCreation.Teid = uint32(teid)
+				dlOuterHeaderCreation.Teid = teid
 				dlOuterHeaderCreation.Ipv4Address = GTPTunnel.TransportLayerAddress.Value.Bytes
 				DLPDR.FAR.State = RULE_UPDATE
 			}

--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -211,10 +211,11 @@ func HandleUpCnxState(txn *transaction.Transaction, response *models.UpdateSmCon
 	return nil
 }
 
-func HandleUpdateHoState(txn *transaction.Transaction, response *models.UpdateSmContextResponse) error {
+func HandleUpdateHoState(txn *transaction.Transaction, response *models.UpdateSmContextResponse, pfcpAction *pfcpAction, pfcpParam *pfcpParam) error {
 	body := txn.Req.(models.UpdateSmContextRequest)
 	smContext := txn.Ctxt.(*context.SMContext)
 	smContextUpdateData := body.JsonData
+	tunnel := smContext.Tunnel
 
 	switch smContextUpdateData.HoState {
 	case models.HoState_PREPARING:
@@ -281,8 +282,44 @@ func HandleUpdateHoState(txn *transaction.Transaction, response *models.UpdateSm
 			smContext.SubPduSessLog.Warnf("PDUSessionSMContextUpdate, SMContext state[%v] should be SmStateActive",
 				smContext.SMContextState.String())
 		}
-		smContext.ChangeState(context.SmStateModify)
-		smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+
+		pdrList := []*context.PDR{}
+		farList := []*context.FAR{}
+
+		smContext.PendingUPF = make(context.PendingUPF)
+		for _, dataPath := range tunnel.DataPathPool {
+			if dataPath.Activated {
+				ANUPF := dataPath.FirstDPNode
+				for _, DLPDR := range ANUPF.DownLinkTunnel.PDR {
+					DLPDR.FAR.ApplyAction = context.ApplyAction{Buff: false, Drop: false, Dupl: false, Forw: true, Nocp: false}
+					DLPDR.FAR.ForwardingParameters = &context.ForwardingParameters{
+						OuterHeaderCreation: DLPDR.FAR.ForwardingParameters.OuterHeaderCreation,
+						DestinationInterface: context.DestinationInterface{
+							InterfaceValue: context.DestinationInterfaceAccess,
+						},
+						NetworkInstance: []byte(smContext.Dnn),
+					}
+
+					DLPDR.State = context.RULE_UPDATE
+					DLPDR.FAR.State = context.RULE_UPDATE
+
+					pdrList = append(pdrList, DLPDR)
+					farList = append(farList, DLPDR.FAR)
+
+					if _, exist := smContext.PendingUPF[ANUPF.GetNodeIP()]; !exist {
+						smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+					}
+				}
+			}
+		}
+
+		pfcpParam.pdrList = append(pfcpParam.pdrList, pdrList...)
+		pfcpParam.farList = append(pfcpParam.farList, farList...)
+
+		pfcpAction.sendPfcpModify = true
+		smContext.ChangeState(context.SmStatePfcpModify)
+		smContext.SubCtxLog.Infoln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+
 		smContext.HoState = models.HoState_COMPLETED
 		response.JsonData.HoState = models.HoState_COMPLETED
 	}

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -360,7 +360,7 @@ func HandlePDUSessionSMContextUpdate(eventData interface{}) error {
 	}
 
 	// Ho state handling
-	if err := HandleUpdateHoState(txn, &response); err != nil {
+	if err := HandleUpdateHoState(txn, &response, pfcpAction, pfcpParam); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix
> /kind enhancement

**What this PR does / why we need it**:
This PR adds PFCP session modification handling after receiving a Handover Notification during the N2 Handover procedure. The modification ensures that user-plane traffic is rerouted to the target gNB TEID instead of the source gNB, enabling seamless data flow continuity post-handover.

**Which issue(s) this PR fixes**:
Fixes #27 

**Test Report Added?**:
> /kind NOT-TESTED

**Test Report**:
Tested with N2-based handover scenario.

- Verified PFCP Session Modification Request is sent to UPF with the correct target gNB TEID and IP.
- Confirmed uplink and downlink traffic is successfully rerouted post-handover.
- Logs and packet captures confirm expected behavior.

**Special notes for your reviewer**:
NIL