### PR TITLE
Crash Fix: SMF Crash Due to Out-of-Bounds Access in SelectedSessionRule Function

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -585,40 +585,27 @@ func (smContext *SMContext) isAllowedPDUSessionType(requestedPDUSessionType uint
 
 // SelectedSessionRule - return the SMF selected session rule for this SM Context
 func (smContext *SMContext) SelectedSessionRule() *models.SessionRule {
-	// Policy update in progress
 	logger.CtxLog.Infof("SelectedSessionRule len(smContext.SmPolicyUpdates): %v", len(smContext.SmPolicyUpdates))
 
-	if smContext.SmPolicyUpdates != nil {
-		logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates: %v", smContext.SmPolicyUpdates)
-	}
-
 	if len(smContext.SmPolicyUpdates) > 0 {
-		if smContext.SmPolicyUpdates[0] != nil {
-			logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0]: %v", smContext.SmPolicyUpdates[0])
-		}
-
-		if smContext.SmPolicyUpdates[0].SessRuleUpdate != nil {
-			logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0].SessRuleUpdate: %v", smContext.SmPolicyUpdates[0].SessRuleUpdate)
-		}
-
-		if smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil {
-			logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule: %v", smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule)
+		policyUpdate := smContext.SmPolicyUpdates[0]
+		if policyUpdate != nil {
+			logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0]: %v", policyUpdate)
+			if policyUpdate.SessRuleUpdate != nil {
+				logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0].SessRuleUpdate: %v", policyUpdate.SessRuleUpdate)
+				if policyUpdate.SessRuleUpdate.ActiveSessRule != nil {
+					logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule: %v", policyUpdate.SessRuleUpdate.ActiveSessRule)
+					return policyUpdate.SessRuleUpdate.ActiveSessRule
+				}
+			}
 		}
 	}
 
 	logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyData: %v", smContext.SmPolicyData)
-
 	logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyData.SmCtxtSessionRules: %v", smContext.SmPolicyData.SmCtxtSessionRules)
-
 	logger.CtxLog.Infof("SelectedSessionRule smContext.SmPolicyData.SmCtxtSessionRules.ActiveRule: %v", smContext.SmPolicyData.SmCtxtSessionRules.ActiveRule)
 
-	if len(smContext.SmPolicyUpdates) > 0 && smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil {
-		logger.CtxLog.Infof("return smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule")
-		return smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule
-	} else {
-		logger.CtxLog.Infof("return smContext.SmPolicyData.SmCtxtSessionRules.ActiveRule")
-		return smContext.SmPolicyData.SmCtxtSessionRules.ActiveRule
-	}
+	return smContext.SmPolicyData.SmCtxtSessionRules.ActiveRule
 }
 
 func (smContextState SMContextState) String() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix

**What this PR does / why we need it**:

This crash disrupts the 5G control plane's stability, particularly affecting the PDU Session Resource Setup procedure. Ensuring robust handling of empty slices in SelectedSessionRule is crucial to maintain uninterrupted service and prevent unexpected terminations.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#78](https://github.com/5GC-DEV/smf-cdac/issues/38)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
