### PR TITLE
SMF Crash Due to N3 Interface Being Nil During Load Test with 10K Subscribers in second iteration

### DIFF
--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -55,6 +55,7 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 	ie.Criticality.Value = ngapType.CriticalityPresentReject
 	logger.CtxLog.Infof("UPF Node: %+v", UpNode)
 	logger.CtxLog.Infof("N3Interfaces count: %d", len(UpNode.N3Interfaces))
+	// Possible cause: N3Interfaces is empty or nil, leading to nil pointer dereference when accessing its elements.
 	if len(UpNode.N3Interfaces) == 0 {
 		return nil, fmt.Errorf("N3Interfaces is empty for UPF: %v", UpNode.N3Interfaces)
 	}

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omec-project/ngap/ngapConvert"
 	"github.com/omec-project/ngap/ngapType"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/smf/logger"
 	"github.com/omec-project/smf/qos"
 )
 
@@ -52,6 +53,11 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 	ie = ngapType.PDUSessionResourceSetupRequestTransferIEs{}
 	ie.Id.Value = ngapType.ProtocolIEIDULNGUUPTNLInformation
 	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	logger.CtxLog.Infof("UPF Node: %+v", UpNode)
+	logger.CtxLog.Infof("N3Interfaces count: %d", len(UpNode.N3Interfaces))
+	if len(UpNode.N3Interfaces) == 0 {
+		return nil, fmt.Errorf("N3Interfaces is empty for UPF: %v", UpNode.N3Interfaces)
+	}
 	if n3IP, err := UpNode.N3Interfaces[0].IP(ctx.SelectedPDUSessionType); err != nil {
 		return nil, err
 	} else {

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -55,7 +55,7 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 	ie.Criticality.Value = ngapType.CriticalityPresentReject
 	logger.CtxLog.Infof("UPF Node: %+v", UpNode)
 	logger.CtxLog.Infof("N3Interfaces count: %d", len(UpNode.N3Interfaces))
-	// Possible cause: N3Interfaces is empty or nil, leading to nil pointer dereference when accessing its elements.
+	// Possible cause: Physical interface connecting to UPF may be down
 	if len(UpNode.N3Interfaces) == 0 {
 		return nil, fmt.Errorf("N3Interfaces is empty for UPF: %v", UpNode.N3Interfaces)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
The crash causes the UEs to fail in PDU session creation.
As a result, the 10K subscriber test case fails in the second iteration.
Stability and scalability of SMF under load is critical for production deployments.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #40

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
--> NA

**Special notes for your reviewer**:
