### PR TITLE
Feat: Implement IMS Call session tear-off handling in SMF to properly manage and terminate IMS sessions. 

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -41,7 +41,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: -v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: -v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/context/datapath.go
+++ b/context/datapath.go
@@ -474,7 +474,6 @@ func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, e
 	logger.PduSessLog.Infof("CreateDedicatedQosQer: total QoSData entries = %d", len(smPolicyDec.QosDecs))
 
 	for qosID, qosData := range smPolicyDec.QosDecs {
-
 		if qosData.DefQosFlowIndication {
 			logger.PduSessLog.Infof("CreateDedicatedQosQer: skipping default QoSData [QosId=%s]", qosID)
 			continue

--- a/context/datapath.go
+++ b/context/datapath.go
@@ -464,16 +464,22 @@ func (dpNode *DataPathNode) CreateSessRuleQer(smContext *SMContext) (*QER, error
 	return flowQER, nil
 }
 
+// CreateDedicatedQosQer creates a dedicated QER (QoS Enforcement Rule) for a PDU session in the given UPF.
+// It processes the SM Policy decision for the UE and creates QERs for each dedicated QoS flow (non-default).
 func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, error) {
 	var createdQER *QER
 
+	// Log start of QER creation
 	logger.PduSessLog.Infof("CreateDedicatedQosQer: start for UE [%s], PDU Session ID [%d]",
 		smContext.Supi, smContext.PDUSessionID)
 
 	smPolicyDec := smContext.SmPolicyUpdates[0].SmPolicyDecision
 	logger.PduSessLog.Infof("CreateDedicatedQosQer: total QoSData entries = %d", len(smPolicyDec.QosDecs))
 
+	// Iterate over all QoSData in SM Policy decision
 	for qosID, qosData := range smPolicyDec.QosDecs {
+
+		// Skip default QoS flows
 		if qosData.DefQosFlowIndication {
 			logger.PduSessLog.Infof("CreateDedicatedQosQer: skipping default QoSData [QosId=%s]", qosID)
 			continue
@@ -481,18 +487,23 @@ func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, e
 
 		logger.PduSessLog.Infof("CreateDedicatedQosQer: processing dedicated QoSData [QosId=%s, 5QI=%d]", qosData.QosId, qosData.Var5qi)
 
-		// Create QER in UPF
+		// Attempt to add a new QER in the UPF
 		if newQER, err := dpNode.UPF.AddQER(); err != nil {
+			// Error creating QER
 			logger.PduSessLog.Errorf("CreateDedicatedQosQer: AddQER failed for UE [%s], QoSId [%s], error: %v",
 				smContext.Supi, qosData.QosId, err)
 			return nil, err
 		} else {
+			// Successfully created QER, set QFI
 			newQER.QFI.QFI = qos.GetQosFlowIdFromQosId(qosData.QosId)
+
+			// Set GateStatus: open UL and DL gates by default
 			newQER.GateStatus = &GateStatus{
 				ULGate: GateOpen,
 				DLGate: GateOpen,
 			}
 
+			// Set Guaranteed Bit Rate (GBR) if configured
 			if qosData.GbrUl != "" && qosData.GbrDl != "" {
 				newQER.GBR = &GBR{
 					ULGBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.GbrUl)),
@@ -504,6 +515,7 @@ func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, e
 				logger.PduSessLog.Infof("CreateDedicatedQosQer: no GBR configured for QoSId [%s]", qosData.QosId)
 			}
 
+			// Set Maximum Bit Rate (MBR) if configured
 			if qosData.MaxbrUl != "" && qosData.MaxbrDl != "" {
 				newQER.MBR = &MBR{
 					ULMBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.MaxbrUl)),
@@ -515,20 +527,25 @@ func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, e
 				logger.PduSessLog.Infof("CreateDedicatedQosQer: no MBR configured for QoSId [%s]", qosData.QosId)
 			}
 
+			// Log the created QER
 			logger.PduSessLog.Infof("CreateDedicatedQosQer: QER created [QER-ID=%d, QFI=%d] for UE [%s], QoSId [%s]",
 				newQER.QERID, newQER.QFI.QFI, smContext.Supi, qosData.QosId)
 
+			// Track the last created QER
 			createdQER = newQER
 		}
 	}
 
+	// If no dedicated QER was created, log a warning
 	if createdQER == nil {
 		logger.PduSessLog.Warnf("CreateDedicatedQosQer: no dedicated QER created for UE [%s]", smContext.Supi)
 		return nil, nil
 	}
 
+	// Log success with last created QER
 	logger.PduSessLog.Infof("CreateDedicatedQosQer: success, last created QER [QER-ID=%d, QFI=%d] for UE [%s]",
 		createdQER.QERID, createdQER.QFI.QFI, smContext.Supi)
+
 	return createdQER, nil
 }
 

--- a/context/datapath.go
+++ b/context/datapath.go
@@ -464,6 +464,75 @@ func (dpNode *DataPathNode) CreateSessRuleQer(smContext *SMContext) (*QER, error
 	return flowQER, nil
 }
 
+func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, error) {
+	var createdQER *QER
+
+	logger.PduSessLog.Infof("CreateDedicatedQosQer: start for UE [%s], PDU Session ID [%d]",
+		smContext.Supi, smContext.PDUSessionID)
+
+	smPolicyDec := smContext.SmPolicyUpdates[0].SmPolicyDecision
+	logger.PduSessLog.Infof("CreateDedicatedQosQer: total QoSData entries = %d", len(smPolicyDec.QosDecs))
+
+	for qosID, qosData := range smPolicyDec.QosDecs {
+
+		if qosData.DefQosFlowIndication {
+			logger.PduSessLog.Infof("CreateDedicatedQosQer: skipping default QoSData [QosId=%s]", qosID)
+			continue
+		}
+
+		logger.PduSessLog.Infof("CreateDedicatedQosQer: processing dedicated QoSData [QosId=%s, 5QI=%d]", qosData.QosId, qosData.Var5qi)
+
+		// Create QER in UPF
+		if newQER, err := dpNode.UPF.AddQER(); err != nil {
+			logger.PduSessLog.Errorf("CreateDedicatedQosQer: AddQER failed for UE [%s], QoSId [%s], error: %v",
+				smContext.Supi, qosData.QosId, err)
+			return nil, err
+		} else {
+			newQER.QFI.QFI = qos.GetQosFlowIdFromQosId(qosData.QosId)
+			newQER.GateStatus = &GateStatus{
+				ULGate: GateOpen,
+				DLGate: GateOpen,
+			}
+
+			if qosData.GbrUl != "" && qosData.GbrDl != "" {
+				newQER.GBR = &GBR{
+					ULGBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.GbrUl)),
+					DLGBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.GbrDl)),
+				}
+				logger.PduSessLog.Infof("CreateDedicatedQosQer: GBR set [UL=%d kbps, DL=%d kbps]",
+					newQER.GBR.ULGBR, newQER.GBR.DLGBR)
+			} else {
+				logger.PduSessLog.Infof("CreateDedicatedQosQer: no GBR configured for QoSId [%s]", qosData.QosId)
+			}
+
+			if qosData.MaxbrUl != "" && qosData.MaxbrDl != "" {
+				newQER.MBR = &MBR{
+					ULMBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.MaxbrUl)),
+					DLMBR: util.BitRateTokbps(util.NormalizeBitRate(qosData.MaxbrDl)),
+				}
+				logger.PduSessLog.Infof("CreateDedicatedQosQer: MBR set [UL=%d kbps, DL=%d kbps]",
+					newQER.MBR.ULMBR, newQER.MBR.DLMBR)
+			} else {
+				logger.PduSessLog.Infof("CreateDedicatedQosQer: no MBR configured for QoSId [%s]", qosData.QosId)
+			}
+
+			logger.PduSessLog.Infof("CreateDedicatedQosQer: QER created [QER-ID=%d, QFI=%d] for UE [%s], QoSId [%s]",
+				newQER.QERID, newQER.QFI.QFI, smContext.Supi, qosData.QosId)
+
+			createdQER = newQER
+		}
+	}
+
+	if createdQER == nil {
+		logger.PduSessLog.Warnf("CreateDedicatedQosQer: no dedicated QER created for UE [%s]", smContext.Supi)
+		return nil, nil
+	}
+
+	logger.PduSessLog.Infof("CreateDedicatedQosQer: success, last created QER [QER-ID=%d, QFI=%d] for UE [%s]",
+		createdQER.QERID, createdQER.QFI.QFI, smContext.Supi)
+	return createdQER, nil
+}
+
 // ActivateUpLinkPdr
 func (dpNode *DataPathNode) ActivateUpLinkPdr(smContext *SMContext, defQER *QER, defPrecedence uint32) error {
 	ueIpAddr := UEIPAddress{}

--- a/context/datapath.go
+++ b/context/datapath.go
@@ -478,7 +478,6 @@ func (dpNode *DataPathNode) CreateDedicatedQosQer(smContext *SMContext) (*QER, e
 
 	// Iterate over all QoSData in SM Policy decision
 	for qosID, qosData := range smPolicyDec.QosDecs {
-
 		// Skip default QoS flows
 		if qosData.DefQosFlowIndication {
 			logger.PduSessLog.Infof("CreateDedicatedQosQer: skipping default QoSData [QosId=%s]", qosID)

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -267,7 +267,6 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 		smContext.SubGsmLog.Debugf("QoS Rules length: %d", len(qosRulesBytes))
 
 		if len(qosRulesBytes) > 0 {
-
 			if pDUSessionModificationCommand.AuthorizedQosRules == nil {
 				pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(nas.MsgTypePDUSessionModificationCommand)
 			}

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -292,6 +292,7 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 		if len(qosRulesBytes) > 0 {
 			pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(
 				nas.MsgTypePDUSessionModificationCommand)
+			pDUSessionModificationCommand.AuthorizedQosRules.SetIei(0x7A)
 			pDUSessionModificationCommand.AuthorizedQosRules.SetLen(uint16(len(qosRulesBytes)))
 			pDUSessionModificationCommand.AuthorizedQosRules.SetQosRule(qosRulesBytes)
 

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -20,6 +20,10 @@ import (
 	errors "github.com/omec-project/smf/smferrors"
 )
 
+const (
+	PTI uint8 = 0 // indicates that the request is initiated by the core network.
+)
+
 type AuthorizedQosRules struct {
 	Iei    uint8
 	Len    uint16
@@ -212,39 +216,57 @@ func BuildGSMPDUSessionReleaseCommand(smContext *SMContext) ([]byte, error) {
 	return m.PlainNasEncode()
 }
 
+// 3GPP Reference: TS 24.501, Section 8.3.4 – "PDU Session Modification Command"
 func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error) {
+	// Initialize NAS message
 	m := nas.NewMessage()
 	m.GsmMessage = nas.NewGsmMessage()
+
+	// Set NAS Message Type and Extended Protocol Discriminator for SM messages
 	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
 	m.GsmHeader.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+
+	// Create PDUSessionModificationCommand IE
 	m.PDUSessionModificationCommand = nasMessage.NewPDUSessionModificationCommand(0x0)
 	pDUSessionModificationCommand := m.PDUSessionModificationCommand
 
 	pDUSessionModificationCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionModificationCommand.SetPDUSessionID(uint8(smContext.PDUSessionID))
-	// Method 1: Simple increment with wraparound
-	pti := uint8(0)
-	pDUSessionModificationCommand.SetPTI(pti)
-	// pDUSessionModificationCommand.SetPTI(0)
+
+	// PTI = 0 indicates core-initiated request
+	pDUSessionModificationCommand.SetPTI(PTI)
+
 	pDUSessionModificationCommand.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
 
-	if len(smContext.SmPolicyUpdates) > 0 {
-		if smContext.SmPolicyUpdates[0].SessRuleUpdate != nil &&
-			smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil &&
-			smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr != nil {
-			modAmbr := nasConvert.ModelsToSessionAMBR(smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr)
-			pDUSessionModificationCommand.SessionAMBR = &modAmbr
-			pDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(pDUSessionModificationCommand.SessionAMBR.Octet)))
+	// ===============================
+	// Set Session-AMBR if available
+	// ===============================
+	if len(smContext.SmPolicyUpdates) > 0 &&
+		smContext.SmPolicyUpdates[0].SessRuleUpdate != nil &&
+		smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil &&
+		smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr != nil {
 
-			smContext.SubGsmLog.Infof("Session-AMBR set for PDU Session Modification Command")
-		}
+		modAmbr := nasConvert.ModelsToSessionAMBR(smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr)
+		pDUSessionModificationCommand.SessionAMBR = &modAmbr
+		pDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(pDUSessionModificationCommand.SessionAMBR.Octet)))
+
+		smContext.SubGsmLog.Infof("Session-AMBR set for PDU Session Modification Command")
 	}
+
+	// ===============================
+	// Build Authorized QoS Flow Descriptions
+	// ===============================
 	authQfd := qos.BuildAuthorizedQosFlowDescriptions(smContext.SmPolicyUpdates[0])
 	if pDUSessionModificationCommand.AuthorizedQosFlowDescriptions == nil {
-		pDUSessionModificationCommand.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType)
+		pDUSessionModificationCommand.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(
+			nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType)
 	}
 	pDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetLen(authQfd.IeLen)
 	pDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetQoSFlowDescriptions(authQfd.Content)
+
+	// ===============================
+	// Build Authorized QoS Rules
+	// ===============================
 	if len(smContext.SmPolicyUpdates) > 0 {
 		qoSRules := qos.BuildQosRulespdumod(smContext.SmPolicyUpdates[0])
 
@@ -257,6 +279,7 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 			}
 		}
 
+		// Marshal QoS rules to binary
 		qosRulesBytes, err := qoSRules.MarshalBinary()
 		if err != nil {
 			smContext.SubGsmLog.Errorf("Failed to marshal QoS rules: %v", err)
@@ -266,22 +289,21 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 		smContext.SubGsmLog.Debugf("QoS Rules raw (hex): %x", qosRulesBytes)
 		smContext.SubGsmLog.Debugf("QoS Rules length: %d", len(qosRulesBytes))
 
+		// If there are QoS rules, create the Authorized QoS Rules IE
 		if len(qosRulesBytes) > 0 {
-			if pDUSessionModificationCommand.AuthorizedQosRules == nil {
-				pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(nas.MsgTypePDUSessionModificationCommand)
-			}
-			pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(nas.MsgTypePDUSessionModificationCommand)
-			pDUSessionModificationCommand.AuthorizedQosRules.SetIei(0x7A)
-			// Now safely set length and rules
-			smContext.SubGsmLog.Debugf("QoS Rules length from MarshalBinary: %d", len(qosRulesBytes))
+			pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(
+				nas.MsgTypePDUSessionModificationCommand)
 			pDUSessionModificationCommand.AuthorizedQosRules.SetLen(uint16(len(qosRulesBytes)))
 			pDUSessionModificationCommand.AuthorizedQosRules.SetQosRule(qosRulesBytes)
+
 			smContext.SubGsmLog.Debugf("AuthorizedQoS IE len: %d", pDUSessionModificationCommand.AuthorizedQosRules.GetLen())
 			smContext.SubGsmLog.Debugf("AuthorizedQoS IE hex: %x", pDUSessionModificationCommand.AuthorizedQosRules.GetQosRule())
 		}
 	}
 
 	smContext.SubGsmLog.Infof("PDU Session Modification Command built successfully for Session ID: %d", smContext.PDUSessionID)
+
+	// Encode NAS message to bytes
 	encoded, err := m.PlainNasEncode()
 	if err != nil {
 		smContext.SubGsmLog.Errorf("Encoding failed: %v", err)
@@ -290,7 +312,6 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 
 	smContext.SubGsmLog.Infof("Successfully encoded message, length: %d, hex: %x", len(encoded), encoded)
 	return encoded, nil
-	// return m.PlainNasEncode()
 }
 
 func BuildGSMPDUSessionReleaseReject(smContext *SMContext) ([]byte, error) {

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -245,7 +245,6 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 		smContext.SmPolicyUpdates[0].SessRuleUpdate != nil &&
 		smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil &&
 		smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr != nil {
-
 		modAmbr := nasConvert.ModelsToSessionAMBR(smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr)
 		pDUSessionModificationCommand.SessionAMBR = &modAmbr
 		pDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(pDUSessionModificationCommand.SessionAMBR.Octet)))

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -8,6 +8,7 @@ package context
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net"
 
 	"github.com/omec-project/nas"
@@ -18,6 +19,12 @@ import (
 	"github.com/omec-project/smf/qos"
 	errors "github.com/omec-project/smf/smferrors"
 )
+
+type AuthorizedQosRules struct {
+	Iei    uint8
+	Len    uint16
+	Buffer []uint8
+}
 
 func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error) {
 	m := nas.NewMessage()
@@ -215,17 +222,76 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 
 	pDUSessionModificationCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionModificationCommand.SetPDUSessionID(uint8(smContext.PDUSessionID))
-	pDUSessionModificationCommand.SetPTI(smContext.Pti)
+	// Method 1: Simple increment with wraparound
+	pti := uint8(0)
+	pDUSessionModificationCommand.SetPTI(pti)
+	// pDUSessionModificationCommand.SetPTI(0)
 	pDUSessionModificationCommand.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
-	// pDUSessionModificationCommand.SetQosRule()
-	// pDUSessionModificationCommand.AuthorizedQosRules.SetLen()
-	// pDUSessionModificationCommand.SessionAMBR.SetSessionAMBRForDownlink([2]uint8{0x11, 0x11})
-	// pDUSessionModificationCommand.SessionAMBR.SetSessionAMBRForUplink([2]uint8{0x11, 0x11})
-	// pDUSessionModificationCommand.SessionAMBR.SetUnitForSessionAMBRForDownlink(10)
-	// pDUSessionModificationCommand.SessionAMBR.SetUnitForSessionAMBRForUplink(10)
-	// pDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(pDUSessionModificationCommand.SessionAMBR.Octet)))
 
-	return m.PlainNasEncode()
+	if len(smContext.SmPolicyUpdates) > 0 {
+		if smContext.SmPolicyUpdates[0].SessRuleUpdate != nil &&
+			smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule != nil &&
+			smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr != nil {
+			modAmbr := nasConvert.ModelsToSessionAMBR(smContext.SmPolicyUpdates[0].SessRuleUpdate.ActiveSessRule.AuthSessAmbr)
+			pDUSessionModificationCommand.SessionAMBR = &modAmbr
+			pDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(pDUSessionModificationCommand.SessionAMBR.Octet)))
+
+			smContext.SubGsmLog.Infof("Session-AMBR set for PDU Session Modification Command")
+		}
+	}
+	authQfd := qos.BuildAuthorizedQosFlowDescriptions(smContext.SmPolicyUpdates[0])
+	if pDUSessionModificationCommand.AuthorizedQosFlowDescriptions == nil {
+		pDUSessionModificationCommand.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType)
+	}
+	pDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetLen(authQfd.IeLen)
+	pDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetQoSFlowDescriptions(authQfd.Content)
+	if len(smContext.SmPolicyUpdates) > 0 {
+		qoSRules := qos.BuildQosRulespdumod(smContext.SmPolicyUpdates[0])
+
+		for _, r := range qoSRules {
+			smContext.SubGsmLog.Debugf("Built QoS Rule ID: %d, QFI: %d, PF Count: %d",
+				r.Identifier, r.QFI, len(r.PacketFilterList))
+			for _, pf := range r.PacketFilterList {
+				smContext.SubGsmLog.Debugf("PF ID: %d, Dir: %d, Content: %s",
+					pf.Identifier, pf.Direction, pf.Content)
+			}
+		}
+
+		qosRulesBytes, err := qoSRules.MarshalBinary()
+		if err != nil {
+			smContext.SubGsmLog.Errorf("Failed to marshal QoS rules: %v", err)
+			return nil, fmt.Errorf("failed to marshal QoS rules: %w", err)
+		}
+
+		smContext.SubGsmLog.Debugf("QoS Rules raw (hex): %x", qosRulesBytes)
+		smContext.SubGsmLog.Debugf("QoS Rules length: %d", len(qosRulesBytes))
+
+		if len(qosRulesBytes) > 0 {
+
+			if pDUSessionModificationCommand.AuthorizedQosRules == nil {
+				pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(nas.MsgTypePDUSessionModificationCommand)
+			}
+			pDUSessionModificationCommand.AuthorizedQosRules = nasType.NewAuthorizedQosRules(nas.MsgTypePDUSessionModificationCommand)
+			pDUSessionModificationCommand.AuthorizedQosRules.SetIei(0x7A)
+			// Now safely set length and rules
+			smContext.SubGsmLog.Debugf("QoS Rules length from MarshalBinary: %d", len(qosRulesBytes))
+			pDUSessionModificationCommand.AuthorizedQosRules.SetLen(uint16(len(qosRulesBytes)))
+			pDUSessionModificationCommand.AuthorizedQosRules.SetQosRule(qosRulesBytes)
+			smContext.SubGsmLog.Debugf("AuthorizedQoS IE len: %d", pDUSessionModificationCommand.AuthorizedQosRules.GetLen())
+			smContext.SubGsmLog.Debugf("AuthorizedQoS IE hex: %x", pDUSessionModificationCommand.AuthorizedQosRules.GetQosRule())
+		}
+	}
+
+	smContext.SubGsmLog.Infof("PDU Session Modification Command built successfully for Session ID: %d", smContext.PDUSessionID)
+	encoded, err := m.PlainNasEncode()
+	if err != nil {
+		smContext.SubGsmLog.Errorf("Encoding failed: %v", err)
+		return nil, err
+	}
+
+	smContext.SubGsmLog.Infof("Successfully encoded message, length: %d, hex: %x", len(encoded), encoded)
+	return encoded, nil
+	// return m.PlainNasEncode()
 }
 
 func BuildGSMPDUSessionReleaseReject(smContext *SMContext) ([]byte, error) {
@@ -262,4 +328,9 @@ func BuildGSMPDUSessionReleaseRejectWithCause(smContext *SMContext, pduSessionID
 	uint8Cause := errors.ErrorCause[cause]
 	pDUSessionReleaseRejectWithCause.SetCauseValue(uint8Cause)
 	return m.PlainNasEncode()
+}
+
+func (a *AuthorizedQosRules) SetQosRule(qosRule []uint8) {
+	a.Buffer = make([]byte, len(qosRule)) // fresh buffer
+	copy(a.Buffer, qosRule)
 }

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -260,11 +260,9 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	priority := sessRule.AuthDefQos.Arp.PriorityLevel
 	qi := sessRule.AuthDefQos.Var5qi
 
-	var policyDecision *qos.SmCtxtPolicyData
-	// policyDecision := ctx.SmPolicyData
+	policyDecision := ctx.SmPolicyData.SmCtxtQosData.QosData
 	if policyDecision != nil {
-		for _, qos := range policyDecision.SmCtxtQosData.QosData {
-			// Example: log GBR/MBR values
+		for _, qos := range policyDecision {
 			ctx.SubPduSessLog.Infof(
 				"QoSId=%s, Var5QI=%d, GBR: UL=%s, DL=%s, MBR: UL=%s, DL=%s",
 				qos.QosId, qos.Var5qi, qos.GbrUl, qos.GbrDl, qos.MaxbrUl, qos.MaxbrDl,
@@ -305,8 +303,6 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	}
 	resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 
-	// Step 2: Get QoS parameters from policy updates (if available) or fallback to session rule
-
 	arpPreemptCap := ngapType.PreEmptionCapabilityPresentMayTriggerPreEmption
 	arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
 
@@ -327,7 +323,6 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 						} else {
 							ctx.SubPduSessLog.Errorf("Invalid QosId string: %s", qosData.QosId)
 						}
-						// qi = qosData.Var5qi
 						if qosData.PriorityLevel > 0 {
 							priority = qosData.PriorityLevel
 						}

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -172,19 +172,30 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 	}
 }
 
+// BuildPDUSessionResourceModifyRequestTransfer builds and encodes
+// the NGAP PDUSessionResourceModifyRequestTransfer message.
+// This is used to update the RAN with QoS flow changes (add/modify/delete).
+// 3GPP TS 38.413 8.2.3v16.2.0 (NGAP: PDU Session Resource Modify Request)
 func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error) {
-	ctx.SubPduSessLog.Infof("Building PDUSessionResourceModifyRequestTransfer for SUPI[%s], PDU Session ID[%d]", ctx.Supi, ctx.PDUSessionID)
+	// Start logging with SUPI and Session ID
+	ctx.SubPduSessLog.Infof(
+		"Building PDUSessionResourceModifyRequestTransfer for SUPI[%s], PDU Session ID[%d]",
+		ctx.Supi, ctx.PDUSessionID,
+	)
 
 	resourceModifyRequestTransfer := ngapType.PDUSessionResourceModifyRequestTransfer{}
 
+	// ----------------------------------------------------
+	// Step 1: Check if only QosFlowToReleaseList should be sent
+	// ----------------------------------------------------
 	shouldSendReleaseOnly := false
 	if len(ctx.SmPolicyUpdates) > 0 && ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules != nil {
-		// Check if PccRules map is empty
+		// If PccRules map is empty → release only
 		if len(ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules) == 0 {
 			shouldSendReleaseOnly = true
 			logger.PduSessLog.Warnln("PccRules map is empty, setting shouldSendReleaseOnly = true")
 		} else {
-			// Check if any PCC rule has nil or empty ID
+			// If any PCC rule is invalid (nil or empty ID) → release only
 			for ruleId, rule := range ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules {
 				if ruleId == "" || rule == nil || rule.PccRuleId == "" {
 					shouldSendReleaseOnly = true
@@ -195,6 +206,9 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 		}
 	}
 
+	// ----------------------------------------------------
+	// Step 2: Handle Release-Only Case
+	// ----------------------------------------------------
 	if shouldSendReleaseOnly {
 		ctx.SubPduSessLog.Info("PCC rule ID is nil, sending only QosFlowToReleaseList")
 
@@ -204,9 +218,9 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 			ctx.SubPduSessLog.Error("SelectedSessionRule is nil")
 			return nil, fmt.Errorf("sessRule is nil")
 		}
-
 		qfi := sessRule.AuthDefQos.Var5qi
 
+		// Build QoS Flow Release List
 		qosFlowToReleaseList := ngapType.QosFlowListWithCause{}
 		qosFlowToReleaseList.List = append(qosFlowToReleaseList.List, ngapType.QosFlowWithCauseItem{
 			QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qfi)},
@@ -216,13 +230,10 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 			},
 		})
 
+		// Add IE to NGAP transfer message
 		ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{
-			Id: ngapType.ProtocolIEID{
-				Value: ngapType.ProtocolIEIDQosFlowToReleaseList,
-			},
-			Criticality: ngapType.Criticality{
-				Value: ngapType.CriticalityPresentReject,
-			},
+			Id:          ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDQosFlowToReleaseList},
+			Criticality: ngapType.Criticality{Value: ngapType.CriticalityPresentReject},
 			Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
 				Present:              ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowToReleaseList,
 				QosFlowToReleaseList: &qosFlowToReleaseList,
@@ -231,7 +242,7 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 		resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 		ctx.SubPduSessLog.Infof("Appended QosFlowToReleaseList with %d entries", len(qosFlowToReleaseList.List))
 
-		// Skip AMBR and QoS flow modifications, go directly to encoding
+		// Encode the NGAP message and return
 		ctx.SubPduSessLog.Info("Encoding PDUSessionResourceModifyRequestTransfer structure (QosFlowToReleaseList only)")
 		if buf, err := aper.MarshalWithParams(resourceModifyRequestTransfer, "valueExt"); err != nil {
 			ctx.SubPduSessLog.Errorf("Failed to encode PDUSessionResourceModifyRequestTransfer: %v", err)
@@ -242,24 +253,35 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 		}
 	}
 
+	// ----------------------------------------------------
+	// Step 3: Normal QoS Add/Modify Case
+	// ----------------------------------------------------
+
+	// Get selected session rule
 	sessRule := ctx.SelectedSessionRule()
 	if sessRule == nil {
 		ctx.SubPduSessLog.Error("SelectedSessionRule is nil")
 		return nil, fmt.Errorf("sessRule is nil")
 	}
 
+	// Session AMBR must be present
 	if sessRule.AuthSessAmbr == nil {
 		ctx.SubPduSessLog.Error("AuthSessAmbr is nil")
 		return nil, fmt.Errorf("no PDU Session AMBR")
 	}
 
-	// Take AMBR first (session level)
+	// Extract AMBR values
 	gbdownlink := ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Downlink)
 	gbuplink := ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Uplink)
+
+	// Default QoS params from session rule
 	qfi := sessRule.AuthDefQos.Var5qi
 	priority := sessRule.AuthDefQos.Arp.PriorityLevel
 	qi := sessRule.AuthDefQos.Var5qi
 
+	// ----------------------------------------------------
+	// Step 4: Check QoS Policy Decision overrides
+	// ----------------------------------------------------
 	policyDecision := ctx.SmPolicyData.SmCtxtQosData.QosData
 	if policyDecision != nil {
 		for _, qos := range policyDecision {
@@ -267,8 +289,7 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 				"QoSId=%s, Var5QI=%d, GBR: UL=%s, DL=%s, MBR: UL=%s, DL=%s",
 				qos.QosId, qos.Var5qi, qos.GbrUl, qos.GbrDl, qos.MaxbrUl, qos.MaxbrDl,
 			)
-
-			// If GBR is available, override AMBR for this flow
+			// Override AMBR with GBR if available
 			if qos.GbrDl != "" {
 				if val, err := StringToBitRate(qos.GbrDl); err == nil {
 					gbdownlink = int64(val)
@@ -282,17 +303,13 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 			qi = qos.Var5qi
 		}
 	}
+	ctx.SubPduSessLog.Infof("Using QoS: DL = %d bps, UL = %d bps, qfi = %d , arp = %d ",
+		gbdownlink, gbuplink, qfi, priority)
 
-	ctx.SubPduSessLog.Infof("Using QoS: DL = %d bps, UL = %d bps, qfi = %d , arp = %d ", gbdownlink, gbuplink, qfi, priority)
-
-	// Build NGAP IE
+	// Add AMBR IE to NGAP message
 	ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{
-		Id: ngapType.ProtocolIEID{
-			Value: ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate,
-		},
-		Criticality: ngapType.Criticality{
-			Value: ngapType.CriticalityPresentReject,
-		},
+		Id:          ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate},
+		Criticality: ngapType.Criticality{Value: ngapType.CriticalityPresentReject},
 		Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
 			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentPDUSessionAggregateMaximumBitRate,
 			PDUSessionAggregateMaximumBitRate: &ngapType.PDUSessionAggregateMaximumBitRate{
@@ -303,26 +320,30 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	}
 	resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 
+	// Default ARP values
 	arpPreemptCap := ngapType.PreEmptionCapabilityPresentMayTriggerPreEmption
 	arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
 
-	// Check for updated QoS data in policy updates
+	// ----------------------------------------------------
+	// Step 5: Handle policy updates (QoS flow add/modify)
+	// ----------------------------------------------------
 	if len(ctx.SmPolicyUpdates) > 0 {
 		policyUpdate := ctx.SmPolicyUpdates[0]
 		if policyUpdate != nil && policyUpdate.QosFlowUpdate != nil {
 			ctx.SubPduSessLog.Infof("Found QoS flow updates in policy updates")
 
-			// Check for modified QoS data first
+			// Handle modified flows first
 			if len(policyUpdate.QosFlowUpdate.GetModified()) > 0 {
 				for qosId, qosData := range policyUpdate.QosFlowUpdate.GetModified() {
 					if qosData != nil {
-						ctx.SubPduSessLog.Infof("Found modified QoS data for QosId[%s]: Var5QI=%d", qosId, qosData.Var5qi)
-						// Convert QosId string -> int32
+						ctx.SubPduSessLog.Infof("Modified QoS data: QosId[%s], Var5QI=%d", qosId, qosData.Var5qi)
+						// Convert QosId string to int
 						if qfiVal, err := strconv.Atoi(qosData.QosId); err == nil {
 							qfi = int32(qfiVal)
 						} else {
 							ctx.SubPduSessLog.Errorf("Invalid QosId string: %s", qosData.QosId)
 						}
+						// Apply priority and ARP if present
 						if qosData.PriorityLevel > 0 {
 							priority = qosData.PriorityLevel
 						}
@@ -335,24 +356,21 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 								arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
 							}
 						}
-						break // Use the first modified QoS data found
+						break
 					}
 				}
 			}
 
-			// Check for added QoS data if no modifications found
+			// Handle added flows if no modified ones
 			if len(policyUpdate.QosFlowUpdate.GetAdded()) > 0 {
 				for qosId, qosData := range policyUpdate.QosFlowUpdate.GetAdded() {
 					if qosData != nil {
-						ctx.SubPduSessLog.Infof("Found added QoS data for QosId[%s]: Var5QI=%d", qosId, qosData.Var5qi)
-
-						// Convert QosId string -> int32
+						ctx.SubPduSessLog.Infof("Added QoS data: QosId[%s], Var5QI=%d", qosId, qosData.Var5qi)
 						if qfiVal, err := strconv.Atoi(qosData.QosId); err == nil {
 							qfi = int32(qfiVal)
 						} else {
 							ctx.SubPduSessLog.Errorf("Invalid QosId string: %s", qosData.QosId)
 						}
-						// qi = qosData.Var5qi
 						if qosData.PriorityLevel > 0 {
 							priority = qosData.PriorityLevel
 						}
@@ -365,14 +383,14 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 								arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
 							}
 						}
-						break // Use the first added QoS data found
+						break
 					}
 				}
 			}
 		}
 	}
 
-	// Apply ARP settings based on session rule if not overridden above
+	// Apply ARP defaults from session rule if not overridden
 	if sessRule.AuthDefQos.Arp.PreemptCap == models.PreemptionCapability_NOT_PREEMPT {
 		arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
 	}
@@ -380,47 +398,42 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 		arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
 	}
 
-	ctx.SubPduSessLog.Infof("Final QoS Flow: QFI = %d, Priority = %d, PreemptCap = %d, PreemptVul = %d",
-		qfi, priority, arpPreemptCap, arpPreemptVul)
+	ctx.SubPduSessLog.Infof(
+		"Final QoS Flow: QFI = %d, Priority = %d, PreemptCap = %d, PreemptVul = %d",
+		qfi, priority, arpPreemptCap, arpPreemptVul,
+	)
 
+	// Build QoS AddOrModify IE
 	ie = ngapType.PDUSessionResourceModifyRequestTransferIEs{
-		Id: ngapType.ProtocolIEID{
-			Value: ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList,
-		},
-		Criticality: ngapType.Criticality{
-			Value: ngapType.CriticalityPresentReject,
-		},
+		Id:          ngapType.ProtocolIEID{Value: ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList},
+		Criticality: ngapType.Criticality{Value: ngapType.CriticalityPresentReject},
 		Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
 			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowAddOrModifyRequestList,
 			QosFlowAddOrModifyRequestList: &ngapType.QosFlowAddOrModifyRequestList{
-				List: []ngapType.QosFlowAddOrModifyRequestItem{
-					{
-						QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qfi)},
-						QosFlowLevelQosParameters: &ngapType.QosFlowLevelQosParameters{
-							QosCharacteristics: ngapType.QosCharacteristics{
-								Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
-								NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
-									FiveQI: ngapType.FiveQI{Value: int64(qi)},
-								},
-							},
-							AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
-								PriorityLevelARP: ngapType.PriorityLevelARP{Value: int64(priority)},
-								PreEmptionCapability: ngapType.PreEmptionCapability{
-									Value: arpPreemptCap,
-								},
-								PreEmptionVulnerability: ngapType.PreEmptionVulnerability{
-									Value: arpPreemptVul,
-								},
+				List: []ngapType.QosFlowAddOrModifyRequestItem{{
+					QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qfi)},
+					QosFlowLevelQosParameters: &ngapType.QosFlowLevelQosParameters{
+						QosCharacteristics: ngapType.QosCharacteristics{
+							Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
+							NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
+								FiveQI: ngapType.FiveQI{Value: int64(qi)},
 							},
 						},
+						AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
+							PriorityLevelARP:        ngapType.PriorityLevelARP{Value: int64(priority)},
+							PreEmptionCapability:    ngapType.PreEmptionCapability{Value: arpPreemptCap},
+							PreEmptionVulnerability: ngapType.PreEmptionVulnerability{Value: arpPreemptVul},
+						},
 					},
-				},
+				}},
 			},
 		},
 	}
 	resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 
-	// Step 3: Encoding
+	// ----------------------------------------------------
+	// Step 6: Encode NGAP message
+	// ----------------------------------------------------
 	ctx.SubPduSessLog.Info("Encoding PDUSessionResourceModifyRequestTransfer structure")
 	if buf, err := aper.MarshalWithParams(resourceModifyRequestTransfer, "valueExt"); err != nil {
 		ctx.SubPduSessLog.Errorf("Failed to encode PDUSessionResourceModifyRequestTransfer: %v", err)
@@ -431,6 +444,13 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	}
 }
 
+// This function is needed because QoS parameters in 3GPP specifications (e.g., GBR, MBR)
+// are often provisioned or configured as strings with units (kbps/mbps),
+// but internally the SMF/UPF and PFCP signaling require numeric values in bps.
+//
+// Supported units:
+//   - "kbps" → kilobits per second (multiplied by 1,000)
+//   - "mbps" → megabits per second (multiplied by 1,000,000)
 func StringToBitRate(s string) (uint64, error) {
 	s = strings.ToLower(strings.TrimSpace(s))
 	if strings.HasSuffix(s, "kbps") {

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -7,6 +7,8 @@ package context
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/omec-project/aper"
 	"github.com/omec-project/ngap/ngapConvert"
@@ -162,61 +164,6 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 
 		resourceSetupRequestTransfer.ProtocolIEs.List = append(resourceSetupRequestTransfer.ProtocolIEs.List, ie)
 	}
-	/*else {
-		//Do not Delete- Might have to enable default Session rule based flow later
-
-		// QoS Flow Setup Request List
-		// Get QFI from PCF
-		ie = ngapType.PDUSessionResourceSetupRequestTransferIEs{}
-		ie.Id.Value = ngapType.ProtocolIEIDQosFlowSetupRequestList
-		ie.Criticality.Value = ngapType.CriticalityPresentReject
-
-		arpPreemptCap := ngapType.PreEmptionCapabilityPresentMayTriggerPreEmption
-		if sessRule.AuthDefQos.Arp.PreemptCap == models.PreemptionCapability_NOT_PREEMPT {
-			arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
-		}
-
-		arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
-		if sessRule.AuthDefQos.Arp.PreemptVuln == models.PreemptionVulnerability_PREEMPTABLE {
-			arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
-		}
-		//Default Session Rule
-		ie.Value = ngapType.PDUSessionResourceSetupRequestTransferIEsValue{
-			Present: ngapType.PDUSessionResourceSetupRequestTransferIEsPresentQosFlowSetupRequestList,
-			QosFlowSetupRequestList: &ngapType.QosFlowSetupRequestList{
-
-				List: []ngapType.QosFlowSetupRequestItem{
-					{
-						QosFlowIdentifier: ngapType.QosFlowIdentifier{
-							Value: int64(sessRule.AuthDefQos.Var5qi), //DefaultNonGBR5QI,
-						},
-						QosFlowLevelQosParameters: ngapType.QosFlowLevelQosParameters{
-							QosCharacteristics: ngapType.QosCharacteristics{
-								Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
-								NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
-									FiveQI: ngapType.FiveQI{
-										Value: int64(sessRule.AuthDefQos.Var5qi), //DefaultNonGBR5QI,
-									},
-								},
-							},
-							AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
-								PriorityLevelARP: ngapType.PriorityLevelARP{
-									Value: int64(sessRule.AuthDefQos.Arp.PriorityLevel), //15,
-								},
-								PreEmptionCapability: ngapType.PreEmptionCapability{
-									Value: arpPreemptCap, //ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption,
-								},
-								PreEmptionVulnerability: ngapType.PreEmptionVulnerability{
-									Value: arpPreemptVul, //ngapType.PreEmptionVulnerabilityPresentNotPreEmptable,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		resourceSetupRequestTransfer.ProtocolIEs.List = append(resourceSetupRequestTransfer.ProtocolIEs.List, ie)
-	}*/
 
 	if buf, err := aper.MarshalWithParams(resourceSetupRequestTransfer, "valueExt"); err != nil {
 		return nil, fmt.Errorf("encode resourceSetupRequestTransfer failed: %s", err)
@@ -226,78 +173,249 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 }
 
 func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error) {
+	ctx.SubPduSessLog.Infof("Building PDUSessionResourceModifyRequestTransfer for SUPI[%s], PDU Session ID[%d]", ctx.Supi, ctx.PDUSessionID)
+
 	resourceModifyRequestTransfer := ngapType.PDUSessionResourceModifyRequestTransfer{}
 
-	// PDU Session Aggregate Maximum Bit Rate
-	// This IE is Conditional and shall be present when at least one NonGBR QoS flow is being setup.
-	// TODO: should check if there is at least one NonGBR QoS flow
-	ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{}
-	ie.Id.Value = ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate
-	ie.Criticality.Value = ngapType.CriticalityPresentReject
-	sessRule := ctx.SelectedSessionRule()
+	shouldSendReleaseOnly := false
+	if len(ctx.SmPolicyUpdates) > 0 && ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules != nil {
+		// Check if PccRules map is empty
+		if len(ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules) == 0 {
+			shouldSendReleaseOnly = true
+			logger.PduSessLog.Warnln("PccRules map is empty, setting shouldSendReleaseOnly = true")
+		} else {
+			// Check if any PCC rule has nil or empty ID
+			for ruleId, rule := range ctx.SmPolicyUpdates[0].SmPolicyDecision.PccRules {
+				if ruleId == "" || rule == nil || rule.PccRuleId == "" {
+					shouldSendReleaseOnly = true
+					logger.PduSessLog.Warnf("Invalid PCC Rule found (ruleId='%s'), setting shouldSendReleaseOnly = true", ruleId)
+					break
+				}
+			}
+		}
+	}
 
+	if shouldSendReleaseOnly {
+		ctx.SubPduSessLog.Info("PCC rule ID is nil, sending only QosFlowToReleaseList")
+
+		// Get QFI from session rule for release
+		sessRule := ctx.SelectedSessionRule()
+		if sessRule == nil {
+			ctx.SubPduSessLog.Error("SelectedSessionRule is nil")
+			return nil, fmt.Errorf("sessRule is nil")
+		}
+
+		qfi := sessRule.AuthDefQos.Var5qi
+
+		qosFlowToReleaseList := ngapType.QosFlowListWithCause{}
+		qosFlowToReleaseList.List = append(qosFlowToReleaseList.List, ngapType.QosFlowWithCauseItem{
+			QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qfi)},
+			Cause: ngapType.Cause{
+				Present: ngapType.CausePresentNas,
+				Nas:     &ngapType.CauseNas{Value: ngapType.CauseNasPresentNormalRelease},
+			},
+		})
+
+		ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{
+			Id: ngapType.ProtocolIEID{
+				Value: ngapType.ProtocolIEIDQosFlowToReleaseList,
+			},
+			Criticality: ngapType.Criticality{
+				Value: ngapType.CriticalityPresentReject,
+			},
+			Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
+				Present:              ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowToReleaseList,
+				QosFlowToReleaseList: &qosFlowToReleaseList,
+			},
+		}
+		resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
+		ctx.SubPduSessLog.Infof("Appended QosFlowToReleaseList with %d entries", len(qosFlowToReleaseList.List))
+
+		// Skip AMBR and QoS flow modifications, go directly to encoding
+		ctx.SubPduSessLog.Info("Encoding PDUSessionResourceModifyRequestTransfer structure (QosFlowToReleaseList only)")
+		if buf, err := aper.MarshalWithParams(resourceModifyRequestTransfer, "valueExt"); err != nil {
+			ctx.SubPduSessLog.Errorf("Failed to encode PDUSessionResourceModifyRequestTransfer: %v", err)
+			return nil, fmt.Errorf("encode resourceModifyRequestTransfer failed: %w", err)
+		} else {
+			ctx.SubPduSessLog.Infof("Successfully built and encoded PDUSessionResourceModifyRequestTransfer (QosFlowToReleaseList only)")
+			return buf, nil
+		}
+	}
+
+	sessRule := ctx.SelectedSessionRule()
 	if sessRule == nil {
+		ctx.SubPduSessLog.Error("SelectedSessionRule is nil")
 		return nil, fmt.Errorf("sessRule is nil")
 	}
 
 	if sessRule.AuthSessAmbr == nil {
+		ctx.SubPduSessLog.Error("AuthSessAmbr is nil")
 		return nil, fmt.Errorf("no PDU Session AMBR")
 	}
-	ie.Value = ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
-		Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentPDUSessionAggregateMaximumBitRate,
-		PDUSessionAggregateMaximumBitRate: &ngapType.PDUSessionAggregateMaximumBitRate{
-			PDUSessionAggregateMaximumBitRateDL: ngapType.BitRate{
-				Value: ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Downlink),
-			},
-			PDUSessionAggregateMaximumBitRateUL: ngapType.BitRate{
-				Value: ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Uplink),
+
+	// Take AMBR first (session level)
+	gbdownlink := ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Downlink)
+	gbuplink := ngapConvert.UEAmbrToInt64(sessRule.AuthSessAmbr.Uplink)
+	qfi := sessRule.AuthDefQos.Var5qi
+	priority := sessRule.AuthDefQos.Arp.PriorityLevel
+	qi := sessRule.AuthDefQos.Var5qi
+
+	var policyDecision *qos.SmCtxtPolicyData
+	// policyDecision := ctx.SmPolicyData
+	if policyDecision != nil {
+		for _, qos := range policyDecision.SmCtxtQosData.QosData {
+			// Example: log GBR/MBR values
+			ctx.SubPduSessLog.Infof(
+				"QoSId=%s, Var5QI=%d, GBR: UL=%s, DL=%s, MBR: UL=%s, DL=%s",
+				qos.QosId, qos.Var5qi, qos.GbrUl, qos.GbrDl, qos.MaxbrUl, qos.MaxbrDl,
+			)
+
+			// If GBR is available, override AMBR for this flow
+			if qos.GbrDl != "" {
+				if val, err := StringToBitRate(qos.GbrDl); err == nil {
+					gbdownlink = int64(val)
+				}
+			}
+			if qos.GbrUl != "" {
+				if val, err := StringToBitRate(qos.GbrUl); err == nil {
+					gbuplink = int64(val)
+				}
+			}
+			qi = qos.Var5qi
+		}
+	}
+
+	ctx.SubPduSessLog.Infof("Using QoS: DL = %d bps, UL = %d bps, qfi = %d , arp = %d ", gbdownlink, gbuplink, qfi, priority)
+
+	// Build NGAP IE
+	ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{
+		Id: ngapType.ProtocolIEID{
+			Value: ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate,
+		},
+		Criticality: ngapType.Criticality{
+			Value: ngapType.CriticalityPresentReject,
+		},
+		Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
+			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentPDUSessionAggregateMaximumBitRate,
+			PDUSessionAggregateMaximumBitRate: &ngapType.PDUSessionAggregateMaximumBitRate{
+				PDUSessionAggregateMaximumBitRateDL: ngapType.BitRate{Value: gbdownlink},
+				PDUSessionAggregateMaximumBitRateUL: ngapType.BitRate{Value: gbuplink},
 			},
 		},
 	}
 	resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 
-	// QoS Flow Modify Request List
-	// use Default 5qi, arp
-	// TODO: Get QFI from PCF/UDM
+	// Step 2: Get QoS parameters from policy updates (if available) or fallback to session rule
+
 	arpPreemptCap := ngapType.PreEmptionCapabilityPresentMayTriggerPreEmption
+	arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
+
+	// Check for updated QoS data in policy updates
+	if len(ctx.SmPolicyUpdates) > 0 {
+		policyUpdate := ctx.SmPolicyUpdates[0]
+		if policyUpdate != nil && policyUpdate.QosFlowUpdate != nil {
+			ctx.SubPduSessLog.Infof("Found QoS flow updates in policy updates")
+
+			// Check for modified QoS data first
+			if len(policyUpdate.QosFlowUpdate.GetModified()) > 0 {
+				for qosId, qosData := range policyUpdate.QosFlowUpdate.GetModified() {
+					if qosData != nil {
+						ctx.SubPduSessLog.Infof("Found modified QoS data for QosId[%s]: Var5QI=%d", qosId, qosData.Var5qi)
+						// Convert QosId string -> int32
+						if qfiVal, err := strconv.Atoi(qosData.QosId); err == nil {
+							qfi = int32(qfiVal)
+						} else {
+							ctx.SubPduSessLog.Errorf("Invalid QosId string: %s", qosData.QosId)
+						}
+						// qi = qosData.Var5qi
+						if qosData.PriorityLevel > 0 {
+							priority = qosData.PriorityLevel
+						}
+						if qosData.Arp != nil {
+							priority = qosData.Arp.PriorityLevel
+							if qosData.Arp.PreemptCap == models.PreemptionCapability_NOT_PREEMPT {
+								arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
+							}
+							if qosData.Arp.PreemptVuln == models.PreemptionVulnerability_PREEMPTABLE {
+								arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
+							}
+						}
+						break // Use the first modified QoS data found
+					}
+				}
+			}
+
+			// Check for added QoS data if no modifications found
+			if len(policyUpdate.QosFlowUpdate.GetAdded()) > 0 {
+				for qosId, qosData := range policyUpdate.QosFlowUpdate.GetAdded() {
+					if qosData != nil {
+						ctx.SubPduSessLog.Infof("Found added QoS data for QosId[%s]: Var5QI=%d", qosId, qosData.Var5qi)
+
+						// Convert QosId string -> int32
+						if qfiVal, err := strconv.Atoi(qosData.QosId); err == nil {
+							qfi = int32(qfiVal)
+						} else {
+							ctx.SubPduSessLog.Errorf("Invalid QosId string: %s", qosData.QosId)
+						}
+						// qi = qosData.Var5qi
+						if qosData.PriorityLevel > 0 {
+							priority = qosData.PriorityLevel
+						}
+						if qosData.Arp != nil {
+							priority = qosData.Arp.PriorityLevel
+							if qosData.Arp.PreemptCap == models.PreemptionCapability_NOT_PREEMPT {
+								arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
+							}
+							if qosData.Arp.PreemptVuln == models.PreemptionVulnerability_PREEMPTABLE {
+								arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
+							}
+						}
+						break // Use the first added QoS data found
+					}
+				}
+			}
+		}
+	}
+
+	// Apply ARP settings based on session rule if not overridden above
 	if sessRule.AuthDefQos.Arp.PreemptCap == models.PreemptionCapability_NOT_PREEMPT {
 		arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
 	}
-
-	arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
 	if sessRule.AuthDefQos.Arp.PreemptVuln == models.PreemptionVulnerability_PREEMPTABLE {
 		arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
 	}
 
-	ie = ngapType.PDUSessionResourceModifyRequestTransferIEs{}
-	ie.Id.Value = ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList
-	ie.Criticality.Value = ngapType.CriticalityPresentReject
-	ie.Value = ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
-		Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowAddOrModifyRequestList,
-		QosFlowAddOrModifyRequestList: &ngapType.QosFlowAddOrModifyRequestList{
-			List: []ngapType.QosFlowAddOrModifyRequestItem{
-				{
-					QosFlowIdentifier: ngapType.QosFlowIdentifier{
-						Value: int64(sessRule.AuthDefQos.Var5qi), // DefaultNonGBR5QI,
-					},
-					QosFlowLevelQosParameters: &ngapType.QosFlowLevelQosParameters{
-						QosCharacteristics: ngapType.QosCharacteristics{
-							Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
-							NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
-								FiveQI: ngapType.FiveQI{
-									Value: int64(sessRule.AuthDefQos.Var5qi), // DefaultNonGBR5QI,
+	ctx.SubPduSessLog.Infof("Final QoS Flow: QFI = %d, Priority = %d, PreemptCap = %d, PreemptVul = %d",
+		qfi, priority, arpPreemptCap, arpPreemptVul)
+
+	ie = ngapType.PDUSessionResourceModifyRequestTransferIEs{
+		Id: ngapType.ProtocolIEID{
+			Value: ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList,
+		},
+		Criticality: ngapType.Criticality{
+			Value: ngapType.CriticalityPresentReject,
+		},
+		Value: ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
+			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowAddOrModifyRequestList,
+			QosFlowAddOrModifyRequestList: &ngapType.QosFlowAddOrModifyRequestList{
+				List: []ngapType.QosFlowAddOrModifyRequestItem{
+					{
+						QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qfi)},
+						QosFlowLevelQosParameters: &ngapType.QosFlowLevelQosParameters{
+							QosCharacteristics: ngapType.QosCharacteristics{
+								Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
+								NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
+									FiveQI: ngapType.FiveQI{Value: int64(qi)},
 								},
 							},
-						},
-						AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
-							PriorityLevelARP: ngapType.PriorityLevelARP{
-								Value: int64(sessRule.AuthDefQos.Arp.PriorityLevel), // 15,
-							},
-							PreEmptionCapability: ngapType.PreEmptionCapability{
-								Value: arpPreemptCap, // ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption,
-							},
-							PreEmptionVulnerability: ngapType.PreEmptionVulnerability{
-								Value: arpPreemptVul, // ngapType.PreEmptionVulnerabilityPresentNotPreEmptable,
+							AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
+								PriorityLevelARP: ngapType.PriorityLevelARP{Value: int64(priority)},
+								PreEmptionCapability: ngapType.PreEmptionCapability{
+									Value: arpPreemptCap,
+								},
+								PreEmptionVulnerability: ngapType.PreEmptionVulnerability{
+									Value: arpPreemptVul,
+								},
 							},
 						},
 					},
@@ -305,15 +423,36 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 			},
 		},
 	}
-
 	resourceModifyRequestTransfer.ProtocolIEs.List = append(resourceModifyRequestTransfer.ProtocolIEs.List, ie)
 
-	// Encode
+	// Step 3: Encoding
+	ctx.SubPduSessLog.Info("Encoding PDUSessionResourceModifyRequestTransfer structure")
 	if buf, err := aper.MarshalWithParams(resourceModifyRequestTransfer, "valueExt"); err != nil {
-		return nil, fmt.Errorf("encode resourceModifyRequestTransfer failed: %s", err)
+		ctx.SubPduSessLog.Errorf("Failed to encode PDUSessionResourceModifyRequestTransfer: %v", err)
+		return nil, fmt.Errorf("encode resourceModifyRequestTransfer failed: %w", err)
 	} else {
+		ctx.SubPduSessLog.Infof("Successfully built and encoded PDUSessionResourceModifyRequestTransfer")
 		return buf, nil
 	}
+}
+
+func StringToBitRate(s string) (uint64, error) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if strings.HasSuffix(s, "kbps") {
+		val, err := strconv.ParseUint(strings.TrimSuffix(s, "kbps"), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return val * 1000, nil
+	}
+	if strings.HasSuffix(s, "mbps") {
+		val, err := strconv.ParseUint(strings.TrimSuffix(s, "mbps"), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return val * 1000 * 1000, nil
+	}
+	return 0, nil
 }
 
 func BuildPDUSessionResourceReleaseCommandTransfer(ctx *SMContext) (buf []byte, err error) {

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -246,26 +246,41 @@ func (smContext *SMContext) ChangeState(nextState SMContextState) {
 			if smContext.Tunnel.DataPathPool[1].FirstDPNode.UPF.NodeID.NodeIdType == NodeIdTypeFqdn {
 				upf = string(smContext.Tunnel.DataPathPool[1].FirstDPNode.UPF.NodeID.NodeIdValue)
 				upf = strings.Split(upf, ".")[0]
+				smContext.SubCtxLog.Infof("Resolved UPF Node FQDN: %s", upf)
 			} else {
 				upf = smContext.Tunnel.DataPathPool[1].FirstDPNode.UPF.GetUPFIP()
+				smContext.SubCtxLog.Infof("Resolved UPF Node IP: %s", upf)
 			}
+		} else {
+			smContext.SubCtxLog.Warn("No UPF tunnel available while changing state")
 		}
 
 		// enterprise name
 		ent := "na"
 		if smfContext.EnterpriseList != nil {
 			entMap := *smfContext.EnterpriseList
-			smContext.SubCtxLog.Debugf("context state change, Enterprises configured = [%v], subscriber slice sst [%v], sd [%v]",
+			smContext.SubCtxLog.Debugf("Enterprises configured: [%v], subscriber slice sst [%v], sd [%v]",
 				entMap, smContext.Snssai.Sst, smContext.Snssai.Sd)
-			ent = entMap[strconv.Itoa(int(smContext.Snssai.Sst))+smContext.Snssai.Sd]
+			entKey := strconv.Itoa(int(smContext.Snssai.Sst)) + smContext.Snssai.Sd
+			if val, ok := entMap[entKey]; ok {
+				ent = val
+				smContext.SubCtxLog.Infof("Mapped enterprise for key [%s]: %s", entKey, ent)
+			} else {
+				smContext.SubCtxLog.Warnf("No enterprise mapping found for key [%s], defaulting to 'na'", entKey)
+			}
 		} else {
-			smContext.SubCtxLog.Debug("context state change, enterprise info not available")
+			smContext.SubCtxLog.Debug("Enterprise info not available")
 		}
 
+		// metrics update
 		if nextState == SmStateActive {
+			smContext.SubCtxLog.Infof("Updating metrics for session [%s], IP [%s], next state [%s], UPF [%s], Enterprise [%s], value=1",
+				smContext.Identifier, smContext.PDUAddress.Ip.String(), nextState.String(), upf, ent)
 			metrics.SetSessProfileStats(smContext.Identifier, smContext.PDUAddress.Ip.String(), nextState.String(),
 				upf, ent, 1)
 		} else {
+			smContext.SubCtxLog.Infof("Updating metrics for session [%s], IP [%s], current state [%s], UPF [%s], Enterprise [%s], value=0",
+				smContext.Identifier, smContext.PDUAddress.Ip.String(), smContext.SMContextState.String(), upf, ent)
 			metrics.SetSessProfileStats(smContext.Identifier, smContext.PDUAddress.Ip.String(), smContext.SMContextState.String(),
 				upf, ent, 0)
 		}
@@ -273,8 +288,10 @@ func (smContext *SMContext) ChangeState(nextState SMContextState) {
 
 	smContext.PublishSmCtxtInfo()
 
-	smContext.SubCtxLog.Infof("context state change, current state[%v] next state[%v]",
+	// log state transition at the end
+	smContext.SubCtxLog.Infof("Context state change: current state [%v] → next state [%v]",
 		smContext.SMContextState.String(), nextState.String())
+
 	smContext.SMContextState = nextState
 }
 

--- a/pfcp/message/build.go
+++ b/pfcp/message/build.go
@@ -333,10 +333,12 @@ func BuildPfcpSessionModificationRequest(
 	pdrList []*context.PDR,
 	farList []*context.FAR,
 	qerList []*context.QER,
+	removePDR []*context.PDR,
+	removeFAR []*context.FAR,
+	removeQER []*context.QER,
 ) (*message.SessionModificationRequest, error) {
 	ies := make([]*ie.IE, 0)
 	ies = append(ies, ie.NewFSEID(localSEID, fseidIPv4Address, nil))
-
 	for _, pdr := range pdrList {
 		switch pdr.State {
 		case context.RULE_INITIAL:
@@ -368,6 +370,19 @@ func BuildPfcpSessionModificationRequest(
 		}
 		qer.State = context.RULE_CREATE
 	}
+
+	for _, pdr := range removePDR {
+		ies = append(ies, buildRemovePDRIE(pdr))
+	}
+
+	for _, far := range removeFAR {
+		ies = append(ies, buildRemoveFARIE(far))
+	}
+
+	for _, qer := range removeQER {
+		ies = append(ies, buildRemoveQERIE(qer))
+	}
+
 	return message.NewSessionModificationRequest(
 		0,
 		0,
@@ -408,4 +423,16 @@ func BuildPfcpSessionReportResponse(cause uint8, drobu bool, seqFromUPF uint32, 
 		ie.NewCause(cause),
 		ie.NewPFCPSRRspFlags(uint8(*flag)),
 	)
+}
+
+func buildRemovePDRIE(pdr *context.PDR) *ie.IE {
+	return ie.NewRemovePDR(ie.NewPDRID(pdr.PDRID))
+}
+
+func buildRemoveFARIE(far *context.FAR) *ie.IE {
+	return ie.NewRemoveFAR(ie.NewFARID(far.FARID))
+}
+
+func buildRemoveQERIE(qer *context.QER) *ie.IE {
+	return ie.NewRemoveQER(ie.NewQERID(qer.QERID))
 }

--- a/pfcp/message/build_test.go
+++ b/pfcp/message/build_test.go
@@ -356,7 +356,7 @@ func TestBuildPfcpSessionModificationRequest(t *testing.T) {
 	}
 	qerList := []*context.QER{}
 
-	msg, err := message.BuildPfcpSessionModificationRequest(64, 1, 2, net.ParseIP("2.3.4.5"), pdrList, farList, qerList)
+	msg, err := message.BuildPfcpSessionModificationRequest(64, 1, 2, net.ParseIP("2.3.4.5"), pdrList, farList, qerList, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error building PFCP session modification request: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestBuildPfcpSessionModificationRequestNoOuterHeader(t *testing.T) {
 	}
 	qerList := []*context.QER{}
 
-	msg, err := message.BuildPfcpSessionModificationRequest(64, 1, 2, net.ParseIP("2.3.4.5"), pdrList, farList, qerList)
+	msg, err := message.BuildPfcpSessionModificationRequest(64, 1, 2, net.ParseIP("2.3.4.5"), pdrList, farList, qerList, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error building PFCP session modification request: %v", err)
 	}

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -301,6 +301,9 @@ func SendPfcpSessionModificationRequest(
 	farList []*smf_context.FAR,
 	barList []*smf_context.BAR,
 	qerList []*smf_context.QER,
+	removePDR []*smf_context.PDR,
+	removeFAR []*smf_context.FAR,
+	removeQER []*smf_context.QER,
 	upfPort uint16,
 ) error {
 	seqNum := getSeqNumber()

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -312,7 +312,7 @@ func SendPfcpSessionModificationRequest(
 	if !ok {
 		return fmt.Errorf("PFCP Context not found for NodeID[%s]", upNodeIDStr)
 	}
-	pfcpMsg, err := BuildPfcpSessionModificationRequest(seqNum, pfcpContext.LocalSEID, pfcpContext.RemoteSEID, smf_context.SMF_Self().CPNodeID.ResolveNodeIdToIp(), pdrList, farList, qerList)
+	pfcpMsg, err := BuildPfcpSessionModificationRequest(seqNum, pfcpContext.LocalSEID, pfcpContext.RemoteSEID, smf_context.SMF_Self().CPNodeID.ResolveNodeIdToIp(), pdrList, farList, qerList, removePDR, removeFAR, removeQER)
 	if err != nil {
 		return err
 	}

--- a/pfcp/message/send_test.go
+++ b/pfcp/message/send_test.go
@@ -260,7 +260,7 @@ func TestSendPfcpSessionModificationRequest(t *testing.T) {
 		Conn: conn,
 	}
 
-	err = message.SendPfcpSessionModificationRequest(upNodeID, smContext, pdrList, farList, barList, qerList, 8806)
+	err = message.SendPfcpSessionModificationRequest(upNodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, 8806)
 	if err != nil {
 		t.Errorf("error sending PFCP Session Modification Request: %v", err)
 	}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omec-project/smf/qos"
 	"github.com/omec-project/smf/transaction"
 	"github.com/omec-project/util/httpwrapper"
+	"github.com/omec-project/util/util_3gpp"
 )
 
 var (
@@ -31,110 +32,241 @@ func HandleSMPolicyUpdateNotify(eventData interface{}) error {
 	request := txn.Req.(models.SmPolicyNotification)
 	smContext := txn.Ctxt.(*smfContext.SMContext)
 
+	smContext.SMLock.Lock()
+	defer smContext.SMLock.Unlock()
+
 	logger.PduSessLog.Infoln("In HandleSMPolicyUpdateNotify")
 	pcfPolicyDecision := request.SmPolicyDecision
 
-	if smContext.SMContextState != smfContext.SmStateActive {
-		// Wait till the state becomes SmStateActive again
-		// TODO: implement waiting in concurrent architecture
+	if smContext.SMContextState != smf_context.SmStateActive {
 		logger.PduSessLog.Warnf("SMContext[%s-%02d] should be SmStateActive, but actual %s",
 			smContext.Supi, smContext.PDUSessionID, smContext.SMContextState.String())
 	}
 
-	//TODO: Response data type -
-	//[200 OK] UeCampingRep
-	//[200 OK] array(PartialSuccessReport)
-	//[400 Bad Request] ErrorReport
+	// Derive QoS change
+	logger.PduSessLog.Infof("Building SM Policy Update for UE [%s], PDU Session ID [%d]",
+		smContext.Supi, smContext.PDUSessionID)
 
-	// Derive QoS change(compare existing vs received Policy Decision)
 	policyUpdates := qos.BuildSmPolicyUpdate(&smContext.SmPolicyData, pcfPolicyDecision)
-	smContext.SmPolicyUpdates = append(smContext.SmPolicyUpdates, policyUpdates)
 
-	httpResponse := httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
-	txn.Rsp = httpResponse
+	logger.PduSessLog.Infof("SM Policy Update built: %+v", policyUpdates)
 
-	// Form N1/N2 Msg based on QoS Change and Trigger N1/N2 Msg
-	if err := BuildAndSendQosN1N2TransferMsg(smContext); err != nil {
-		// smContext.CommitSmPolicyDecision(false)
-		// Send error rsp to PCF
-		httpResponse.Status = http.StatusBadRequest
-		txn.Err = err
-		return err
-	}
+	smContext.SmPolicyUpdates = append(smContext.SmPolicyUpdates[:0], policyUpdates)
+	logger.PduSessLog.Infof("Appended SM Policy Update, total updates count: %d",
+		len(smContext.SmPolicyUpdates))
+	logger.PduSessLog.Infof("SmPolicyUpdates: %v", smContext.SmPolicyUpdates)
 
-	// Update UPF
-	// TODO
-
-	// Build `pfcpParam` using the dedicated function
+	// Set state to PFCP Modify before sending PFCP request
+	smContext.ChangeState(smf_context.SmStatePfcpModify)
+	var response models.UpdateSmContextResponse
+	response.JsonData = new(models.SmContextUpdatedData)
+	// Build PFCP parameters
 	pfcpParam := BuildPfcpParam(smContext)
 
-	// Send PFCP Session Modification Request
 	if err := SendPfcpSessionModifyReq(smContext, pfcpParam); err != nil {
-		logger.PduSessLog.Errorf("Failed to send PFCP session modification request: %v", err)
-		httpResponse.Status = http.StatusInternalServerError
+		// PFCP modify failed — revert state and return error
+		smContext.SubCtxLog.Errorf("PFCP session modify error: %v", err)
+		// smContext.ChangeState(prevState)
+		logger.PduSessLog.Infof("SMContext[%s-%02d] state reverted to %s after PFCP error",
+			smContext.Supi, smContext.PDUSessionID, smContext.SMContextState.String())
+
+		// Build HTTP error response for the original transaction
+		httpResponse := makePduCtxtModifyErrRsp(smContext, err.Error())
+		txn.Err = err
+		txn.Rsp = httpResponse
+		return err
+	}
+
+	smContext.SubCtxLog.Infoln("SMContextState Change State:", smContext.SMContextState.String())
+	logger.PduSessLog.Infof("PFCP modify successful for UE [%s], PDU Session ID [%d]",
+		smContext.Supi, smContext.PDUSessionID)
+
+	// Now send N1/N2 Msg after PFCP success
+	if err := BuildAndSendQosN1N2TransferMsg(smContext); err != nil {
+		logger.PduSessLog.Errorf("Failed to build/send N1/N2 QoS transfer message: %v", err)
 		txn.Err = err
 		return err
 	}
 
-	// N1N2 and UPF update Success
-	// Commit SM Policy Decision to SM Context
-	// TODO
-	// smContext.SMLock.Lock()
-	// defer smContext.SMLock.Unlock()
-	// smContext.CommitSmPolicyDecision(true)
+	// Set response and change state to active
+	smContext.ChangeState(smf_context.SmStateActive)
+	smContext.SubCtxLog.Info("PFCP Modify success and N1N2 Msg sent, new state:", smContext.SMContextState.String())
+
+	httpResponse := &httpwrapper.Response{
+		Status: http.StatusOK,
+		Body:   nil,
+	}
 	txn.Rsp = httpResponse
+
 	return nil
 }
 
 func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 	pfcpParam := &pfcpParam{
-		pdrList: []*smf_context.PDR{},
-		farList: []*smf_context.FAR{},
-		barList: []*smf_context.BAR{},
-		qerList: []*smf_context.QER{},
+		pdrList:   []*smfContext.PDR{},
+		farList:   []*smfContext.FAR{},
+		barList:   []*smfContext.BAR{},
+		qerList:   []*smfContext.QER{},
+		removePDR: []*smfContext.PDR{},
+		removeFAR: []*smfContext.FAR{},
+		removeQER: []*smfContext.QER{},
 	}
 
 	smContext.PendingUPF = make(smfContext.PendingUPF)
-	var pdrList []*smf_context.PDR
-	var farList []*smf_context.FAR
 
-	logger.PduSessLog.Infof("SMContext: %v", smContext)
-	logger.PduSessLog.Infof("SMContext SmPolicyUpdates: %v", smContext.SmPolicyUpdates)
-
-	// Iterate over the Data Path Pool
-	for _, dataPath := range smContext.Tunnel.DataPathPool {
-		if dataPath.Activated {
-			ANUPF := dataPath.FirstDPNode
-			for _, DLPDR := range ANUPF.DownLinkTunnel.PDR {
-				// Update FAR actions
-				DLPDR.FAR.ApplyAction = smfContext.ApplyAction{Buff: false, Drop: false, Dupl: false, Forw: true, Nocp: false}
-				DLPDR.FAR.ForwardingParameters = &smfContext.ForwardingParameters{
-					OuterHeaderCreation: DLPDR.FAR.ForwardingParameters.OuterHeaderCreation,
-					DestinationInterface: smfContext.DestinationInterface{
-						InterfaceValue: smfContext.DestinationInterfaceAccess,
-					},
-					NetworkInstance: []byte(smContext.Dnn),
-				}
-
-				// Mark rules as updated
-				DLPDR.State = smfContext.RULE_UPDATE
-				DLPDR.FAR.State = smfContext.RULE_UPDATE
-
-				// Append to lists
-				pdrList = append(pdrList, DLPDR)
-				farList = append(farList, DLPDR.FAR)
-
-				// Track UPF
-				if _, exist := smContext.PendingUPF[ANUPF.GetNodeIP()]; !exist {
-					smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+	shouldSendReleaseOnly := false
+	ruleid := "0"
+	if len(smContext.SmPolicyUpdates) > 0 && smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules != nil {
+		if len(smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules) == 0 {
+			shouldSendReleaseOnly = true
+		} else {
+			for ruleId, rule := range smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules {
+				logger.PduSessLog.Infof("[BuildPfcpParam] Checking PCC RuleId=%s, Rule=%+v", ruleId, rule)
+				ruleid = ruleId
+				if ruleId == "" || rule == nil || rule.PccRuleId == "" {
+					shouldSendReleaseOnly = true
+					break
 				}
 			}
 		}
 	}
+	logger.PduSessLog.Infof("[BuildPfcpParam] Checking PCC RuleId=%s", ruleid)
+	for dpIndex, dataPath := range smContext.Tunnel.DataPathPool {
+		logger.PduSessLog.Infof("[BuildPfcpParam] Processing DataPath[%d], Activated=%v", dpIndex, dataPath.Activated)
+		if !dataPath.Activated {
+			logger.PduSessLog.Infof("Skipping inactive DataPath: %+v", dataPath)
+			continue
+		}
 
-	// Append to pfcpParam
-	pfcpParam.pdrList = append(pfcpParam.pdrList, pdrList...)
-	pfcpParam.farList = append(pfcpParam.farList, farList...)
+		ANUPF := dataPath.FirstDPNode
+		var dedQER *smf_context.QER
+		var err error
+		logger.PduSessLog.Infof("Processing DataPath with UPF Node: %s", ANUPF.GetNodeIP())
+		if !shouldSendReleaseOnly {
+			dedQER, err = ANUPF.CreateDedicatedQosQer(smContext)
+			if err != nil {
+				logger.PduSessLog.Warnf("[BuildPfcpParam] CreateSessRuleQer failed: %v", err)
+			} else {
+				logger.PduSessLog.Infof("[BuildPfcpParam] Created default QER: %+v", dedQER)
+			}
+
+			if err := dataPath.ActivateUlDlTunnel(smContext); err != nil {
+				logger.PduSessLog.Errorf("activate UL/DL tunnel error %v", err.Error())
+			}
+		}
+		// ----------------------
+		// Handle Downlink PDRs
+		// ----------------------
+		if dlPDR, ok := ANUPF.DownLinkTunnel.PDR[ruleid]; ok {
+			logger.PduSessLog.Infof("[BuildPfcpParam] Checking DL PDR: Name=%s, ID=%d", ruleid, dlPDR.PDRID)
+			if shouldSendReleaseOnly {
+				logger.PduSessLog.Infof("[BuildPfcpParam] Marking DL PDR[%s] for removal", ruleid)
+				pfcpParam.removePDR = append(pfcpParam.removePDR, dlPDR)
+				if dlPDR.FAR != nil {
+					pfcpParam.removeFAR = append(pfcpParam.removeFAR, dlPDR.FAR)
+				}
+				if dlPDR.QER != nil {
+					for _, qer := range dlPDR.QER {
+						if qer != nil {
+							logger.PduSessLog.Infof(
+								"[BuildPfcpParam] UL PDR[%s] has QER ID [%d], QFI=%d, State=%v",
+								ruleid, qer.QERID, qer.QFI, qer.State,
+							)
+						}
+					}
+					pfcpParam.removeQER = append(pfcpParam.removeQER, dlPDR.QER...)
+				}
+				continue
+			}
+
+			logger.CtxLog.Infof("activate Downlink PDR[%v]:[%v]", ruleid, dlPDR)
+			dlPDR.QER = []*smf_context.QER{dedQER}
+
+			logger.PduSessLog.Infof("[BuildPfcpParam] Replaced DL PDR[%s] QERs with new QER: %+v", ruleid, dlPDR)
+
+			if dlPDR.Precedence == 0 {
+				dlPDR.Precedence = 1
+			}
+			dlPDR.PDI.SourceInterface = smf_context.SourceInterface{InterfaceValue: smf_context.SourceInterfaceCore}
+			dlPDR.PDI.NetworkInstance = util_3gpp.Dnn(smContext.Dnn)
+			logger.PduSessLog.Infof("[BuildPfcpParam] Final DL PDR[%s]: %+v", ruleid, dlPDR)
+
+			dlFAR := dlPDR.FAR
+
+			// FAR ApplyAction
+			dlFAR.ApplyAction = smf_context.ApplyAction{
+				Buff: true,
+				Drop: false,
+				Dupl: false,
+				Forw: false,
+				Nocp: true,
+			}
+
+			// Interface resolution
+			logger.PduSessLog.Infof("Resolving UPF interface for DNN [%s], type [N6]", smContext.Dnn)
+
+			pfcpParam.pdrList = append(pfcpParam.pdrList, dlPDR)
+			if dlFAR != nil {
+				pfcpParam.farList = append(pfcpParam.farList, dlFAR)
+			}
+			if dedQER != nil {
+				pfcpParam.qerList = append(pfcpParam.qerList, dedQER)
+			}
+
+			smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+		}
+
+		// ----------------------
+		// Handle Uplink PDRs
+		// ----------------------
+		if ulPDR, ok := ANUPF.UpLinkTunnel.PDR[ruleid]; ok {
+			if shouldSendReleaseOnly {
+				logger.PduSessLog.Infof("[BuildPfcpParam] Marking UL PDR[%s] for removal", ruleid)
+				pfcpParam.removePDR = append(pfcpParam.removePDR, ulPDR)
+				if ulPDR.FAR != nil {
+					pfcpParam.removeFAR = append(pfcpParam.removeFAR, ulPDR.FAR)
+				}
+				if ulPDR.QER != nil {
+					for _, qer := range ulPDR.QER {
+						if qer != nil {
+							logger.PduSessLog.Infof(
+								"[BuildPfcpParam] UL PDR[%s] has QER ID [%d], QFI=%d, State=%v",
+								ruleid, qer.QERID, qer.QFI, qer.State,
+							)
+						}
+					}
+					pfcpParam.removeQER = append(pfcpParam.removeQER, ulPDR.QER...)
+				}
+				continue
+			}
+			ulPDR.QER = []*smf_context.QER{dedQER}
+			logger.PduSessLog.Infof("[BuildPfcpParam] Replaced DL PDR[%s] QERs with new QER: %+v", ruleid, ulPDR)
+			if ulPDR.Precedence == 0 {
+				ulPDR.Precedence = 1
+			}
+			ulPDR.PDI.SourceInterface = smf_context.SourceInterface{InterfaceValue: smf_context.SourceInterfaceAccess}
+			ulPDR.PDI.LocalFTeid = &smf_context.FTEID{Ch: true}
+			ulPDR.PDI.NetworkInstance = util_3gpp.Dnn(smContext.Dnn)
+			ulPDR.OuterHeaderRemoval = &smf_context.OuterHeaderRemoval{
+				OuterHeaderRemovalDescription: smf_context.OuterHeaderRemovalGtpUUdpIpv4,
+			}
+			ulFAR := ulPDR.FAR
+			ulFAR.ApplyAction = smf_context.ApplyAction{Forw: true}
+			ulFAR.ForwardingParameters = &smf_context.ForwardingParameters{
+				DestinationInterface: smf_context.DestinationInterface{
+					InterfaceValue: smf_context.DestinationInterfaceCore,
+				},
+				NetworkInstance: []byte(smContext.Dnn),
+			}
+
+			pfcpParam.pdrList = append(pfcpParam.pdrList, ulPDR)
+			if ulFAR != nil {
+				pfcpParam.farList = append(pfcpParam.farList, ulFAR)
+			}
+			smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+			logger.CtxLog.Infof("activate UpLink PDR[%v]:[%v]", ruleid, ulPDR)
+		}
+	}
 
 	return pfcpParam
 }
@@ -149,7 +281,7 @@ func BuildAndSendQosN1N2TransferMsg(smContext *smfContext.SMContext) error {
 		SmInfo: &models.N2SmInformation{
 			PduSessionId: smContext.PDUSessionID,
 			N2InfoContent: &models.N2InfoContent{
-				NgapIeType: models.NgapIeType_PDU_RES_SETUP_REQ,
+				NgapIeType: models.NgapIeType_PDU_RES_MOD_REQ,
 				NgapData: &models.RefToBinaryData{
 					ContentId: "N2SmInformation",
 				},

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -99,21 +99,31 @@ func HandleSMPolicyUpdateNotify(eventData interface{}) error {
 	return nil
 }
 
+// BuildPfcpParam constructs the PFCP parameters (PDRs, FARs, QERs,) for a given SMContext.
+// It analyzes the SM Policy updates and the current data paths in the SM context to:
+//  1. Create or modify PDRs (Packet Detection Rules), FARs (Forwarding Action Rules), and QERs (QoS Enforcement Rules).
+//  2. Identify PDRs, FARs, and QERs to be removed if the policy indicates a release-only scenario.
+//  3. Activate UL/DL tunnels on the UPFs if needed.
+//
+// This function returns a pfcpParam structure containing lists of rules to add or remove for PFCP session management.
 func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
+	// Initialize PFCP parameter container
 	pfcpParam := &pfcpParam{
 		pdrList:   []*smfContext.PDR{},
 		farList:   []*smfContext.FAR{},
-		barList:   []*smfContext.BAR{},
 		qerList:   []*smfContext.QER{},
 		removePDR: []*smfContext.PDR{},
 		removeFAR: []*smfContext.FAR{},
 		removeQER: []*smfContext.QER{},
 	}
 
+	// Initialize map to track UPFs pending PFCP configuration
 	smContext.PendingUPF = make(smfContext.PendingUPF)
 
+	// Determine if we only need to release existing rules (no new policy)
 	shouldSendReleaseOnly := false
 	ruleid := "0"
+
 	if len(smContext.SmPolicyUpdates) > 0 && smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules != nil {
 		if len(smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules) == 0 {
 			shouldSendReleaseOnly = true
@@ -121,6 +131,7 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 			for ruleId, rule := range smContext.SmPolicyUpdates[0].SmPolicyDecision.PccRules {
 				logger.PduSessLog.Infof("[BuildPfcpParam] Checking PCC RuleId=%s, Rule=%+v", ruleId, rule)
 				ruleid = ruleId
+				// If any PCC rule is invalid or empty, we treat this as release-only
 				if ruleId == "" || rule == nil || rule.PccRuleId == "" {
 					shouldSendReleaseOnly = true
 					break
@@ -129,6 +140,8 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 		}
 	}
 	logger.PduSessLog.Infof("[BuildPfcpParam] Checking PCC RuleId=%s", ruleid)
+
+	// Iterate over all active data paths in the SM context
 	for dpIndex, dataPath := range smContext.Tunnel.DataPathPool {
 		logger.PduSessLog.Infof("[BuildPfcpParam] Processing DataPath[%d], Activated=%v", dpIndex, dataPath.Activated)
 		if !dataPath.Activated {
@@ -140,6 +153,8 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 		var dedQER *smf_context.QER
 		var err error
 		logger.PduSessLog.Infof("Processing DataPath with UPF Node: %s", ANUPF.GetNodeIP())
+
+		// Only create/activate QERs and tunnels if not release-only
 		if !shouldSendReleaseOnly {
 			dedQER, err = ANUPF.CreateDedicatedQosQer(smContext)
 			if err != nil {
@@ -152,11 +167,14 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 				logger.PduSessLog.Errorf("activate UL/DL tunnel error %v", err.Error())
 			}
 		}
+
 		// ----------------------
 		// Handle Downlink PDRs
 		// ----------------------
 		if dlPDR, ok := ANUPF.DownLinkTunnel.PDR[ruleid]; ok {
 			logger.PduSessLog.Infof("[BuildPfcpParam] Checking DL PDR: Name=%s, ID=%d", ruleid, dlPDR.PDRID)
+
+			// Release-only scenario: mark PDR, FAR, QER for removal
 			if shouldSendReleaseOnly {
 				logger.PduSessLog.Infof("[BuildPfcpParam] Marking DL PDR[%s] for removal", ruleid)
 				pfcpParam.removePDR = append(pfcpParam.removePDR, dlPDR)
@@ -164,45 +182,28 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 					pfcpParam.removeFAR = append(pfcpParam.removeFAR, dlPDR.FAR)
 				}
 				if dlPDR.QER != nil {
-					for _, qer := range dlPDR.QER {
-						if qer != nil {
-							logger.PduSessLog.Infof(
-								"[BuildPfcpParam] UL PDR[%s] has QER ID [%d], QFI=%d, State=%v",
-								ruleid, qer.QERID, qer.QFI, qer.State,
-							)
-						}
-					}
 					pfcpParam.removeQER = append(pfcpParam.removeQER, dlPDR.QER...)
 				}
 				continue
 			}
 
-			logger.CtxLog.Infof("activate Downlink PDR[%v]:[%v]", ruleid, dlPDR)
+			// Attach dedicated QER to DL PDR
 			dlPDR.QER = []*smf_context.QER{dedQER}
-
-			logger.PduSessLog.Infof("[BuildPfcpParam] Replaced DL PDR[%s] QERs with new QER: %+v", ruleid, dlPDR)
-
 			if dlPDR.Precedence == 0 {
 				dlPDR.Precedence = 1
 			}
+
+			// Set PDI fields for core interface
 			dlPDR.PDI.SourceInterface = smf_context.SourceInterface{InterfaceValue: smf_context.SourceInterfaceCore}
 			dlPDR.PDI.NetworkInstance = util_3gpp.Dnn(smContext.Dnn)
-			logger.PduSessLog.Infof("[BuildPfcpParam] Final DL PDR[%s]: %+v", ruleid, dlPDR)
 
+			// Configure FAR for downlink traffic
 			dlFAR := dlPDR.FAR
-
-			// FAR ApplyAction
 			dlFAR.ApplyAction = smf_context.ApplyAction{
-				Buff: true,
-				Drop: false,
-				Dupl: false,
-				Forw: false,
-				Nocp: true,
+				Buff: true, Drop: false, Dupl: false, Forw: false, Nocp: true,
 			}
 
-			// Interface resolution
-			logger.PduSessLog.Infof("Resolving UPF interface for DNN [%s], type [N6]", smContext.Dnn)
-
+			// Append to PFCP param lists
 			pfcpParam.pdrList = append(pfcpParam.pdrList, dlPDR)
 			if dlFAR != nil {
 				pfcpParam.farList = append(pfcpParam.farList, dlFAR)
@@ -219,35 +220,32 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 		// ----------------------
 		if ulPDR, ok := ANUPF.UpLinkTunnel.PDR[ruleid]; ok {
 			if shouldSendReleaseOnly {
-				logger.PduSessLog.Infof("[BuildPfcpParam] Marking UL PDR[%s] for removal", ruleid)
+				// Mark UL PDR, FAR, QER for removal
 				pfcpParam.removePDR = append(pfcpParam.removePDR, ulPDR)
 				if ulPDR.FAR != nil {
 					pfcpParam.removeFAR = append(pfcpParam.removeFAR, ulPDR.FAR)
 				}
 				if ulPDR.QER != nil {
-					for _, qer := range ulPDR.QER {
-						if qer != nil {
-							logger.PduSessLog.Infof(
-								"[BuildPfcpParam] UL PDR[%s] has QER ID [%d], QFI=%d, State=%v",
-								ruleid, qer.QERID, qer.QFI, qer.State,
-							)
-						}
-					}
 					pfcpParam.removeQER = append(pfcpParam.removeQER, ulPDR.QER...)
 				}
 				continue
 			}
+
+			// Attach dedicated QER to UL PDR
 			ulPDR.QER = []*smf_context.QER{dedQER}
-			logger.PduSessLog.Infof("[BuildPfcpParam] Replaced DL PDR[%s] QERs with new QER: %+v", ruleid, ulPDR)
 			if ulPDR.Precedence == 0 {
 				ulPDR.Precedence = 1
 			}
+
+			// Set PDI and outer header removal for access interface
 			ulPDR.PDI.SourceInterface = smf_context.SourceInterface{InterfaceValue: smf_context.SourceInterfaceAccess}
 			ulPDR.PDI.LocalFTeid = &smf_context.FTEID{Ch: true}
 			ulPDR.PDI.NetworkInstance = util_3gpp.Dnn(smContext.Dnn)
 			ulPDR.OuterHeaderRemoval = &smf_context.OuterHeaderRemoval{
 				OuterHeaderRemovalDescription: smf_context.OuterHeaderRemovalGtpUUdpIpv4,
 			}
+
+			// Configure FAR for UL traffic
 			ulFAR := ulPDR.FAR
 			ulFAR.ApplyAction = smf_context.ApplyAction{Forw: true}
 			ulFAR.ForwardingParameters = &smf_context.ForwardingParameters{
@@ -257,10 +255,12 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 				NetworkInstance: []byte(smContext.Dnn),
 			}
 
+			// Append to PFCP param lists
 			pfcpParam.pdrList = append(pfcpParam.pdrList, ulPDR)
 			if ulFAR != nil {
 				pfcpParam.farList = append(pfcpParam.farList, ulFAR)
 			}
+
 			smContext.PendingUPF[ANUPF.GetNodeIP()] = true
 			logger.CtxLog.Infof("activate UpLink PDR[%v]:[%v]", ruleid, ulPDR)
 		}
@@ -269,64 +269,87 @@ func BuildPfcpParam(smContext *smfContext.SMContext) *pfcpParam {
 	return pfcpParam
 }
 
+// 3GPP Reference: TS 23.502 §4.3.3.4 – "PDU Session Modification" procedure
 func BuildAndSendQosN1N2TransferMsg(smContext *smfContext.SMContext) error {
-	// N1N2 Request towards AMF
+	// -------------------------------
+	// Initialize N1N2 Message Transfer Request
+	// -------------------------------
 	n1n2Request := models.N1N2MessageTransferRequest{}
 
-	// N2 Container Info
+	// -------------------------------
+	// Prepare N2 container info (NGAP message)
+	// -------------------------------
 	n2InfoContainer := models.N2InfoContainer{
-		N2InformationClass: models.N2InformationClass_SM,
+		N2InformationClass: models.N2InformationClass_SM, // SM information for NGAP
 		SmInfo: &models.N2SmInformation{
-			PduSessionId: smContext.PDUSessionID,
+			PduSessionId: smContext.PDUSessionID, // PDU session ID
 			N2InfoContent: &models.N2InfoContent{
-				NgapIeType: models.NgapIeType_PDU_RES_MOD_REQ,
+				NgapIeType: models.NgapIeType_PDU_RES_MOD_REQ, // NGAP IE type for PDUSessionResourceModifyRequest
 				NgapData: &models.RefToBinaryData{
-					ContentId: "N2SmInformation",
+					ContentId: "N2SmInformation", // Reference ID for binary data
 				},
 			},
-			SNssai: smContext.Snssai,
+			SNssai: smContext.Snssai, // Slice information
 		},
 	}
 
-	// N1 Container Info
+	// -------------------------------
+	// Prepare N1 container info (NAS message)
+	// -------------------------------
 	n1MsgContainer := models.N1MessageContainer{
-		N1MessageClass:   "SM",
-		N1MessageContent: &models.RefToBinaryData{ContentId: "GSM_NAS"},
+		N1MessageClass:   "SM",                                          // Session Management NAS message
+		N1MessageContent: &models.RefToBinaryData{ContentId: "GSM_NAS"}, // Binary content reference
 	}
 
-	// N1N2 Json Data
-	n1n2Request.JsonData = &models.N1N2MessageTransferReqData{PduSessionId: smContext.PDUSessionID}
+	// -------------------------------
+	// Fill JsonData for N1N2 transfer
+	// -------------------------------
+	n1n2Request.JsonData = &models.N1N2MessageTransferReqData{
+		PduSessionId: smContext.PDUSessionID,
+	}
 
-	// N1 Msg
+	// -------------------------------
+	// Build N1 (NAS) PDU Session Modification Command
+	// -------------------------------
 	if smNasBuf, err := smfContext.BuildGSMPDUSessionModificationCommand(smContext); err != nil {
-		logger.PduSessLog.Errorf("build GSM BuildGSMPDUSessionModificationCommand failed: %s", err)
+		logger.PduSessLog.Errorf("BuildGSMPDUSessionModificationCommand failed: %s", err)
 	} else {
-		n1n2Request.BinaryDataN1Message = smNasBuf
-		n1n2Request.JsonData.N1MessageContainer = &n1MsgContainer
+		n1n2Request.BinaryDataN1Message = smNasBuf                // Attach binary NAS message
+		n1n2Request.JsonData.N1MessageContainer = &n1MsgContainer // Attach N1 container
 	}
 
-	// N2 Msg
+	// -------------------------------
+	// Build N2 (NGAP) PDUSessionResourceModifyRequestTransfer
+	// -------------------------------
 	n2Pdu, err := smfContext.BuildPDUSessionResourceModifyRequestTransfer(smContext)
 	if err != nil {
-		smContext.SubPduSessLog.Errorf("SMPolicyUpdate, build PDUSession Resource Modify Request Transfer Error(%s)", err.Error())
+		smContext.SubPduSessLog.Errorf("Build PDUSessionResourceModifyRequestTransfer failed: %s", err.Error())
 	} else {
-		n1n2Request.BinaryDataN2Information = n2Pdu
-		n1n2Request.JsonData.N2InfoContainer = &n2InfoContainer
+		n1n2Request.BinaryDataN2Information = n2Pdu             // Attach binary NGAP message
+		n1n2Request.JsonData.N2InfoContainer = &n2InfoContainer // Attach N2 container
 	}
 
 	smContext.SubPduSessLog.Infoln("QoS N1N2 transfer initiated")
-	rspData, _, err := smContext.
-		CommunicationClient.
+
+	// -------------------------------
+	// Send N1N2 Message Transfer to AMF
+	// -------------------------------
+	rspData, _, err := smContext.CommunicationClient.
 		N1N2MessageCollectionDocumentApi.
 		N1N2MessageTransfer(context.Background(), smContext.Supi, n1n2Request)
 	if err != nil {
-		smContext.SubPfcpLog.Warnf("send N1N2Transfer failed, %v", err.Error())
+		smContext.SubPfcpLog.Warnf("Send N1N2Transfer failed: %v", err.Error())
 		return err
 	}
+
+	// -------------------------------
+	// Check response cause
+	// -------------------------------
 	if rspData.Cause == models.N1N2MessageTransferCause_N1_MSG_NOT_TRANSFERRED {
-		smContext.SubPfcpLog.Errorf("N1N2MessageTransfer failure, %v", rspData.Cause)
-		return fmt.Errorf("N1N2MessageTransfer failure, %v", rspData.Cause)
+		smContext.SubPfcpLog.Errorf("N1N2MessageTransfer failure: %v", rspData.Cause)
+		return fmt.Errorf("N1N2MessageTransfer failure: %v", rspData.Cause)
 	}
+
 	smContext.SubPduSessLog.Infoln("QoS N1N2 Transfer completed")
 	return nil
 }

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -56,12 +56,10 @@ func HandleSMPolicyUpdateNotify(eventData interface{}) error {
 		len(smContext.SmPolicyUpdates))
 	logger.PduSessLog.Infof("SmPolicyUpdates: %v", smContext.SmPolicyUpdates)
 
-	// Set state to PFCP Modify before sending PFCP request
-	smContext.ChangeState(smf_context.SmStatePfcpModify)
-	var response models.UpdateSmContextResponse
-	response.JsonData = new(models.SmContextUpdatedData)
 	// Build PFCP parameters
 	pfcpParam := BuildPfcpParam(smContext)
+	// Set state to PFCP Modify before sending PFCP request
+	smContext.ChangeState(smf_context.SmStatePfcpModify)
 
 	if err := SendPfcpSessionModifyReq(smContext, pfcpParam); err != nil {
 		// PFCP modify failed — revert state and return error

--- a/producer/datapath.go
+++ b/producer/datapath.go
@@ -55,7 +55,7 @@ func SendPFCPRule(smContext *context.SMContext, dataPath *context.DataPath) {
 			}
 		} else {
 			err := message.SendPfcpSessionModificationRequest(
-				curDataPathNode.UPF.NodeID, smContext, pdrList, farList, nil, qerList, curDataPathNode.UPF.Port)
+				curDataPathNode.UPF.NodeID, smContext, pdrList, farList, nil, qerList, nil, nil, nil, curDataPathNode.UPF.Port)
 			if err != nil {
 				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, curDataPathNode.UPF.NodeID, curDataPathNode.UPF.NodeID.ResolveNodeIdToIp())
 			}
@@ -121,7 +121,7 @@ func SendPFCPRules(smContext *context.SMContext) {
 			}
 		} else {
 			err := message.SendPfcpSessionModificationRequest(
-				pfcp.nodeID, smContext, pfcp.pdrList, pfcp.farList, nil, pfcp.qerList, pfcp.port)
+				pfcp.nodeID, smContext, pfcp.pdrList, pfcp.farList, nil, pfcp.qerList, nil, nil, nil, pfcp.port)
 			if err != nil {
 				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, pfcp.nodeID, pfcp.nodeID.ResolveNodeIdToIp())
 			}

--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -25,10 +25,13 @@ type pfcpAction struct {
 }
 
 type pfcpParam struct {
-	pdrList []*context.PDR
-	farList []*context.FAR
-	barList []*context.BAR
-	qerList []*context.QER
+	pdrList   []*context.PDR
+	farList   []*context.FAR
+	barList   []*context.BAR
+	qerList   []*context.QER
+	removePDR []*context.PDR // Add for teardown
+	removeFAR []*smf_context.FAR
+	removeQER []*smf_context.QER
 }
 
 func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmContextResponse, pfcpAction *pfcpAction) error {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -799,7 +799,7 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 		ANUPF := defaultPath.FirstDPNode
 
 		// Sending PFCP modification with flag set to DROP the packets.
-		err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext, pdrList, farList, barList, qerList, ANUPF.UPF.Port)
+		err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, ANUPF.UPF.Port)
 		if err != nil {
 			smContext.SubPduSessLog.Errorf("pfcp Session Modification Request failed: %v", err)
 		}

--- a/producer/sm_pfcp_handling.go
+++ b/producer/sm_pfcp_handling.go
@@ -16,7 +16,7 @@ func SendPfcpSessionModifyReq(smContext *smf_context.SMContext, pfcpParam *pfcpP
 	defaultPath := smContext.Tunnel.DataPathPool.GetDefaultPath()
 	ANUPF := defaultPath.FirstDPNode
 	err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext,
-		pfcpParam.pdrList, pfcpParam.farList, pfcpParam.barList, pfcpParam.qerList, ANUPF.UPF.Port)
+		pfcpParam.pdrList, pfcpParam.farList, pfcpParam.barList, pfcpParam.qerList, pfcpParam.removePDR, pfcpParam.removeFAR, pfcpParam.removeQER, ANUPF.UPF.Port)
 	if err != nil {
 		smContext.SubCtxLog.Errorf("pfcp session modification failure: %+v", err)
 	}
@@ -25,13 +25,13 @@ func SendPfcpSessionModifyReq(smContext *smf_context.SMContext, pfcpParam *pfcpP
 
 	switch PFCPResponseStatus {
 	case smf_context.SessionUpdateSuccess:
-		smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, PFCP Session Update Success")
+		smContext.SubCtxLog.Infoln("PDUSessionSMContextUpdate, PFCP Session Update Success")
 
 	case smf_context.SessionUpdateFailed:
-		smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, PFCP Session Update Failed")
+		smContext.SubCtxLog.Infoln("PDUSessionSMContextUpdate, PFCP Session Update Failed")
 		fallthrough
 	case smf_context.SessionUpdateTimeout:
-		smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, PFCP Session Modification Timeout")
+		smContext.SubCtxLog.Infoln("PDUSessionSMContextUpdate, PFCP Session Modification Timeout")
 
 		err := fmt.Errorf("pfcp modification failure")
 		return err

--- a/producer/ulcl_procedure.go
+++ b/producer/ulcl_procedure.go
@@ -224,7 +224,7 @@ func EstablishULCL(smContext *context.SMContext) {
 
 			curDPNodeIP := ulcl.NodeID.ResolveNodeIdToIp().String()
 			bpMGR.PendingUPF[curDPNodeIP] = true
-			err = message.SendPfcpSessionModificationRequest(ulcl.NodeID, smContext, pdrList, farList, barList, qerList, ulcl.Port)
+			err = message.SendPfcpSessionModificationRequest(ulcl.NodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, ulcl.Port)
 			if err != nil {
 				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, ulcl.NodeID, ulcl.NodeID.ResolveNodeIdToIp())
 			}
@@ -265,7 +265,7 @@ func UpdatePSA2DownLink(smContext *context.SMContext) {
 				curDPNodeIP := curDataPathNode.UPF.NodeID.ResolveNodeIdToIp().String()
 				bpMGR.PendingUPF[curDPNodeIP] = true
 				err := message.SendPfcpSessionModificationRequest(
-					curDataPathNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, curDataPathNode.UPF.Port)
+					curDataPathNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, curDataPathNode.UPF.Port)
 				if err != nil {
 					logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, curDataPathNode.UPF.NodeID, curDataPathNode.UPF.NodeID.ResolveNodeIdToIp())
 				}
@@ -382,7 +382,7 @@ func UpdateRANAndIUPFUpLink(smContext *context.SMContext) {
 
 			curDPNodeIP := curDPNode.UPF.NodeID.ResolveNodeIdToIp().String()
 			bpMGR.PendingUPF[curDPNodeIP] = true
-			err := message.SendPfcpSessionModificationRequest(curDPNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, curDPNode.UPF.Port)
+			err := message.SendPfcpSessionModificationRequest(curDPNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, curDPNode.UPF.Port)
 			if err != nil {
 				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, curDPNode.UPF.NodeID, curDPNode.UPF.NodeID.ResolveNodeIdToIp())
 			}

--- a/qos/pcc_rule.go
+++ b/qos/pcc_rule.go
@@ -7,6 +7,7 @@ package qos
 
 import (
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/smf/logger"
 )
 
 type PccRulesUpdate struct {
@@ -15,6 +16,7 @@ type PccRulesUpdate struct {
 
 func GetPccRulesUpdate(pcfPccRules, ctxtPccRules map[string]*models.PccRule) *PccRulesUpdate {
 	if len(pcfPccRules) == 0 {
+		logger.PduSessLog.Infoln("[GetPccRulesUpdate] No PCF PCC rules received, returning nil")
 		return nil
 	}
 
@@ -24,21 +26,31 @@ func GetPccRulesUpdate(pcfPccRules, ctxtPccRules map[string]*models.PccRule) *Pc
 		del: make(map[string]*models.PccRule),
 	}
 
+	logger.PduSessLog.Infof("[GetPccRulesUpdate] Comparing PCC rules: PCF(%d) vs CTXT(%d)", len(pcfPccRules), len(ctxtPccRules))
+
 	// Compare against Ctxt rules to get added or modified rules
 	for name, pcfRule := range pcfPccRules {
 		// if pcfRule is nil then it need to be deleted
 		if pcfRule == nil {
+			logger.PduSessLog.Warnf("[GetPccRulesUpdate] PCC rule %q marked for deletion", name)
 			change.del[name] = pcfRule // nil
 			continue
 		}
 
 		// match against SM ctxt Rules for add/mod
 		if ctxtrule := ctxtPccRules[name]; ctxtrule == nil {
+			logger.PduSessLog.Infof("[GetPccRulesUpdate] PCC rule %q marked for addition", name)
 			change.add[name] = pcfRule
 		} else if GetPccRuleChanges(pcfRule, ctxtrule) {
+			logger.PduSessLog.Infof("[GetPccRulesUpdate] PCC rule %q marked for modification", name)
 			change.mod[name] = pcfRule
+		} else {
+			logger.PduSessLog.Debugf("[GetPccRulesUpdate] PCC rule %q unchanged", name)
 		}
 	}
+
+	logger.PduSessLog.Infof("[GetPccRulesUpdate] Summary: add=%d, mod=%d, del=%d",
+		len(change.add), len(change.mod), len(change.del))
 
 	return &change
 }
@@ -66,8 +78,50 @@ func CommitPccRulesUpdate(smCtxtPolData *SmCtxtPolicyData, update *PccRulesUpdat
 
 // Get the difference between 2 pcc rules
 func GetPccRuleChanges(s, d *models.PccRule) bool {
-	// TODO
+	if s == nil || d == nil {
+		return true
+	}
+
+	if s.PccRuleId != d.PccRuleId ||
+		s.AppId != d.AppId ||
+		s.ContVer != d.ContVer ||
+		s.Precedence != d.Precedence ||
+		s.AfSigProtocol != d.AfSigProtocol ||
+		s.AppReloc != d.AppReloc ||
+		s.RefCondData != d.RefCondData {
+		return true
+	}
+
+	if !stringSlicesEqual(s.RefQosData, d.RefQosData) ||
+		!stringSlicesEqual(s.RefTcData, d.RefTcData) ||
+		!stringSlicesEqual(s.RefChgData, d.RefChgData) ||
+		!stringSlicesEqual(s.RefUmData, d.RefUmData) {
+		return true
+	}
+
+	if len(s.FlowInfos) != len(d.FlowInfos) {
+		return true
+	}
+	for i := range s.FlowInfos {
+		if s.FlowInfos[i] != d.FlowInfos[i] {
+			return true
+		}
+	}
+
 	return false
+}
+
+// Helper to compare two string slices (order matters)
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (upd *PccRulesUpdate) GetAddPccRuleUpdate() map[string]*models.PccRule {

--- a/qos/qos_flow.go
+++ b/qos/qos_flow.go
@@ -202,8 +202,6 @@ func (qfd *QosFlowDescriptionsAuthorized) Validate() error {
 	return nil
 }
 
-// Add these getter methods to your QosFlowsUpdate struct
-
 func (q *QosFlowsUpdate) GetModified() map[string]*models.QosData {
 	if q == nil {
 		return nil

--- a/qos/qos_flow.go
+++ b/qos/qos_flow.go
@@ -92,38 +92,42 @@ func GetQosFlowIdFromQosId(qosId string) uint8 {
 	}
 }
 
-/*func GetQosFlowIdFromQosIdhardcode(qosId string) uint8 {
-	return 2
-}*/
-
 // Build Qos Flow Description to be sent to UE
 func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowDescriptionsAuthorized {
+	// Initialize QoS Flow Descriptions structure
 	QFDescriptions := QosFlowDescriptionsAuthorized{
 		IeType:  nasMessage.PDUSessionEstablishmentAcceptAuthorizedQosFlowDescriptionsType,
 		Content: make([]byte, 0),
 	}
 
 	qosFlowUpdate := smPolicyUpdates.QosFlowUpdate
-	hasUpdates := false
+	hasUpdates := false // Track if any QoS flows were processed
 
-	// Check if there are any QoS flow updates
+	// ===============================
+	// Handle PCC rule deletions if QoS flow updates are nil
+	// ===============================
 	if smPolicyUpdates == nil || smPolicyUpdates.QosFlowUpdate == nil {
 		logger.QosLog.Warn("smPolicyUpdates or QosFlowUpdate is nil, processing PCC rule deletions only")
 
 		for pccRuleID := range smPolicyUpdates.PccRuleUpdate.del {
 			logger.QosLog.Infof("Processing deletion for PCC rule ID: %s", pccRuleID)
+
 			qfiVal, err := strconv.Atoi(pccRuleID)
 			if err != nil {
 				logger.QosLog.Errorf("Invalid QFI string for PCC rule ID '%s': %v", pccRuleID, err)
 				continue
 			}
-
 			qfi := uint8(qfiVal)
+
 			logger.QosLog.Infof("Deleting QoS Flow Description for QFI=%d (from PCC rule %s)", qfi, pccRuleID)
+
+			// Skip if QFI is zero
 			if qfi == 0 {
 				logger.QosLog.Warnf("Skipping QoS Flow deletion because QFI=0 for PCC rule ID='%s'", pccRuleID)
 				continue
 			}
+
+			// Build delete QoS Flow Description
 			QFDescriptions.BuildDelQosFlowDescFromQoSDesc(qfi)
 			hasUpdates = true
 		}
@@ -134,8 +138,12 @@ func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowD
 			logger.QosLog.Warn("No QoS flow deletions were processed")
 		}
 	}
+
+	// ===============================
+	// Handle Add/Modify/Delete QoS Flow updates
+	// ===============================
 	if qosFlowUpdate != nil {
-		// QoS Flow Description to be Added
+		// Add QoS flows
 		if len(qosFlowUpdate.add) > 0 {
 			logger.QosLog.Infof("Processing %d QoS flows to add", len(qosFlowUpdate.add))
 			for name, qosFlow := range qosFlowUpdate.add {
@@ -145,7 +153,7 @@ func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowD
 			}
 		}
 
-		// QoS Flow Description to be Modified
+		// Modify QoS flows
 		if len(qosFlowUpdate.mod) > 0 {
 			logger.QosLog.Infof("Processing %d QoS flows to modify", len(qosFlowUpdate.mod))
 			for name, qosFlow := range qosFlowUpdate.mod {
@@ -155,7 +163,7 @@ func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowD
 			}
 		}
 
-		// QoS Flow Description to be Deleted
+		// Delete QoS flows
 		if len(qosFlowUpdate.del) > 0 {
 			logger.QosLog.Infof("Processing %d QoS flows to delete", len(qosFlowUpdate.del))
 			for qfiStr := range qosFlowUpdate.del {
@@ -172,9 +180,13 @@ func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowD
 			}
 		}
 	}
-	// Set the length based on the content
+
+	// ===============================
+	// Set IE length based on content
+	// ===============================
 	QFDescriptions.IeLen = uint16(len(QFDescriptions.Content))
 
+	// Logging summary
 	if !hasUpdates {
 		logger.QosLog.Warn("No valid QoS flow updates processed, returning empty QoS flow descriptions")
 	} else {
@@ -223,6 +235,9 @@ func (q *QosFlowsUpdate) GetDeleted() map[string]*models.QosData {
 	return q.del
 }
 
+// BuildAddQosFlowDescFromQoSDesc builds a new QoS Flow Description (QFD)
+// for the "create new QoS flow" operation, based on QoS data from PCF.
+// This is used when a new QoS flow is authorized by policy control.
 func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *models.QosData) {
 	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
 
@@ -263,6 +278,9 @@ func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *
 	d.AddQFD(&qfd)
 }
 
+// BuildModQosFlowDescFromQoSDesc builds a QoS Flow Description (QFD)
+// for the "modify existing QoS flow" operation, based on updated QoS data.
+// Only parameters that are present and need to be modified are added.
 func (d *QosFlowDescriptionsAuthorized) BuildModQosFlowDescFromQoSDesc(qosData *models.QosData) {
 	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
 
@@ -306,6 +324,9 @@ func (d *QosFlowDescriptionsAuthorized) BuildModQosFlowDescFromQoSDesc(qosData *
 	d.AddQFD(&qfd)
 }
 
+// BuildDelQosFlowDescFromQoSDesc builds a QoS Flow Description (QFD)
+// for the "delete existing QoS flow" operation, for a given QFI.
+// Unlike Add/Modify, no parameters are included in the delete operation.
 func (d *QosFlowDescriptionsAuthorized) BuildDelQosFlowDescFromQoSDesc(qfi uint8) {
 	logger.QosLog.Infof("Building Delete QoS Flow Description for QFI=%d", qfi)
 

--- a/qos/qos_flow.go
+++ b/qos/qos_flow.go
@@ -5,6 +5,7 @@
 package qos
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -91,6 +92,10 @@ func GetQosFlowIdFromQosId(qosId string) uint8 {
 	}
 }
 
+/*func GetQosFlowIdFromQosIdhardcode(qosId string) uint8 {
+	return 2
+}*/
+
 // Build Qos Flow Description to be sent to UE
 func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowDescriptionsAuthorized {
 	QFDescriptions := QosFlowDescriptionsAuthorized{
@@ -99,22 +104,125 @@ func BuildAuthorizedQosFlowDescriptions(smPolicyUpdates *PolicyUpdate) *QosFlowD
 	}
 
 	qosFlowUpdate := smPolicyUpdates.QosFlowUpdate
+	hasUpdates := false
 
-	// QoS Flow Description to be Added
-	if qosFlowUpdate != nil {
-		for name, qosFlow := range qosFlowUpdate.add {
-			logger.QosLog.Infof("adding Qos Flow Description [%v]", name)
-			QFDescriptions.BuildAddQosFlowDescFromQoSDesc(qosFlow)
+	// Check if there are any QoS flow updates
+	if smPolicyUpdates == nil || smPolicyUpdates.QosFlowUpdate == nil {
+		logger.QosLog.Warn("smPolicyUpdates or QosFlowUpdate is nil, processing PCC rule deletions only")
+
+		for pccRuleID := range smPolicyUpdates.PccRuleUpdate.del {
+			logger.QosLog.Infof("Processing deletion for PCC rule ID: %s", pccRuleID)
+			qfiVal, err := strconv.Atoi(pccRuleID)
+			if err != nil {
+				logger.QosLog.Errorf("Invalid QFI string for PCC rule ID '%s': %v", pccRuleID, err)
+				continue
+			}
+
+			qfi := uint8(qfiVal)
+			logger.QosLog.Infof("Deleting QoS Flow Description for QFI=%d (from PCC rule %s)", qfi, pccRuleID)
+			if qfi == 0 {
+				logger.QosLog.Warnf("Skipping QoS Flow deletion because QFI=0 for PCC rule ID='%s'", pccRuleID)
+				continue
+			}
+			QFDescriptions.BuildDelQosFlowDescFromQoSDesc(qfi)
+			hasUpdates = true
+		}
+
+		if hasUpdates {
+			logger.QosLog.Infof("Completed building delete QoS flow descriptions for %d PCC rules", len(smPolicyUpdates.PccRuleUpdate.del))
+		} else {
+			logger.QosLog.Warn("No QoS flow deletions were processed")
 		}
 	}
+	if qosFlowUpdate != nil {
+		// QoS Flow Description to be Added
+		if len(qosFlowUpdate.add) > 0 {
+			logger.QosLog.Infof("Processing %d QoS flows to add", len(qosFlowUpdate.add))
+			for name, qosFlow := range qosFlowUpdate.add {
+				logger.QosLog.Infof("Adding QoS Flow Description [%v]", name)
+				QFDescriptions.BuildAddQosFlowDescFromQoSDesc(qosFlow)
+				hasUpdates = true
+			}
+		}
 
-	// QoS Flow Description to be Modified
-	// TODO
+		// QoS Flow Description to be Modified
+		if len(qosFlowUpdate.mod) > 0 {
+			logger.QosLog.Infof("Processing %d QoS flows to modify", len(qosFlowUpdate.mod))
+			for name, qosFlow := range qosFlowUpdate.mod {
+				logger.QosLog.Infof("Modifying QoS Flow Description [%v]", name)
+				QFDescriptions.BuildAddQosFlowDescFromQoSDesc(qosFlow)
+				hasUpdates = true
+			}
+		}
 
-	// QoS Flow Description to be Deleted
-	// TODO
+		// QoS Flow Description to be Deleted
+		if len(qosFlowUpdate.del) > 0 {
+			logger.QosLog.Infof("Processing %d QoS flows to delete", len(qosFlowUpdate.del))
+			for qfiStr := range qosFlowUpdate.del {
+				qfiVal, err := strconv.Atoi(qfiStr)
+				if err != nil {
+					logger.QosLog.Errorf("invalid QFI string: %s, err: %v", qfiStr, err)
+					continue
+				}
+				qfi := uint8(qfiVal)
+
+				logger.QosLog.Infof("Deleting QoS Flow Description [QFI=%v]", qfi)
+				QFDescriptions.BuildDelQosFlowDescFromQoSDesc(qfi)
+				hasUpdates = true
+			}
+		}
+	}
+	// Set the length based on the content
+	QFDescriptions.IeLen = uint16(len(QFDescriptions.Content))
+
+	if !hasUpdates {
+		logger.QosLog.Warn("No valid QoS flow updates processed, returning empty QoS flow descriptions")
+	} else {
+		logger.QosLog.Infof("Built QoS flow descriptions with %d bytes of content", QFDescriptions.IeLen)
+	}
 
 	return &QFDescriptions
+}
+
+// Helper function to validate QoS flow descriptions before sending
+func (qfd *QosFlowDescriptionsAuthorized) IsEmpty() bool {
+	return qfd.IeLen == 0 || len(qfd.Content) == 0
+}
+
+// Helper function to validate QoS flow descriptions
+func (qfd *QosFlowDescriptionsAuthorized) Validate() error {
+	if qfd.IeLen != uint16(len(qfd.Content)) {
+		return fmt.Errorf("length mismatch: IeLen=%d, Content length=%d", qfd.IeLen, len(qfd.Content))
+	}
+
+	if qfd.IeLen == 0 {
+		return fmt.Errorf("empty QoS flow descriptions")
+	}
+
+	return nil
+}
+
+// Add these getter methods to your QosFlowsUpdate struct
+
+func (q *QosFlowsUpdate) GetModified() map[string]*models.QosData {
+	if q == nil {
+		return nil
+	}
+	return q.mod
+}
+
+func (q *QosFlowsUpdate) GetAdded() map[string]*models.QosData {
+	if q == nil {
+		return nil
+	}
+	return q.add
+}
+
+func (q *QosFlowsUpdate) GetDeleted() map[string]*models.QosData {
+	if q == nil {
+		return nil
+	}
+	return q.del
 }
 
 func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *models.QosData) {
@@ -157,31 +265,76 @@ func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *
 	d.AddQFD(&qfd)
 }
 
-func BuildModQosFlowDescFromQoSDesc(qosData *models.QosData) {
-	// TODO
-}
-
-func BuildDelQosFlowDescFromQoSDesc(qosData *models.QosData) {
+func (d *QosFlowDescriptionsAuthorized) BuildModQosFlowDescFromQoSDesc(qosData *models.QosData) {
 	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
 
 	// Set QFI
-	qfd.SetQoSFlowDescQfi(uint8(qosData.Var5qi))
+	qfd.SetQoSFlowDescQfi(GetQosFlowIdFromQosId(qosData.QosId))
 
 	// Operation Code
+	qfd.SetQoSFlowDescOpCode(QFDOpModify)
+	logger.QosLog.Infof("OpCode after setting: 0x%02x\n", qfd.OpCode)
+
+	// Modify Params - only add parameters that need to be modified
+	// 5QI (if changed)
+	if qosData.Var5qi != 0 {
+		qfd.AddQosFlowParam5Qi(uint8(qosData.Var5qi))
+	}
+
+	// MFBR uplink (if changed)
+	if qosData.MaxbrUl != "" {
+		qfd.addQosFlowRateParam(qosData.MaxbrUl, QFDParameterIdMfbrUl)
+	}
+
+	// MFBR downlink (if changed)
+	if qosData.MaxbrDl != "" {
+		qfd.addQosFlowRateParam(qosData.MaxbrDl, QFDParameterIdMfbrDl)
+	}
+
+	// GFBR uplink (if changed)
+	if qosData.GbrUl != "" {
+		qfd.addQosFlowRateParam(qosData.GbrUl, QFDParameterIdGfbrUl)
+	}
+
+	// GFBR downlink (if changed)
+	if qosData.GbrDl != "" {
+		qfd.addQosFlowRateParam(qosData.GbrDl, QFDParameterIdGfbrDl)
+	}
+
+	// Set E-Bit of QFD for the "modify existing QoS flow description" operation
+	qfd.SetQFDEBitCreateNewQFD()
+
+	// Add QFD to Authorised QFD IE
+	d.AddQFD(&qfd)
+}
+
+func (d *QosFlowDescriptionsAuthorized) BuildDelQosFlowDescFromQoSDesc(qfi uint8) {
+	logger.QosLog.Infof("Building Delete QoS Flow Description for QFI=%d", qfi)
+
+	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
+
+	// Set QFI
+	qfd.SetQoSFlowDescQfi(qfi)
+	logger.QosLog.Infof("Set QFI=%d in QoSFlowDescription", qfi)
+
+	// Operation Code = Delete existing QoS flow description
 	qfd.SetQoSFlowDescOpCode(QFDOpDelete)
+	logger.QosLog.Infof("Set Operation Code = Delete (%d)", QFDOpDelete)
 
-	// Delete Params
-	// No Params need to be added
-
-	// Set E-Bit of QFD for the "Delete existing QoS flow description" operation
+	// No parameters, E-bit must be 0
 	qfd.SetQFDEBitDeleteExistingQFD()
+	logger.QosLog.Infof("Set E-bit for delete existing QoS Flow Description")
+
+	// Append to list
+	d.AddQFD(&qfd)
+	logger.QosLog.Infof("Appended Delete QoS Flow Description for QFI=%d to QFDescriptions list; current total=%d", qfi, len(d.Content))
 }
 
 func GetBitRate(sBitRate string) (val uint16, unit uint8) {
 	sl := strings.Fields(sBitRate)
 
 	// rate
-	if rate, err := strconv.Atoi(sl[0]); err != nil {
+	if rate, err := strconv.ParseFloat(sl[0], 64); err != nil {
 		logger.QosLog.Errorf("invalid bit rate [%v]", sBitRate)
 	} else {
 		val = uint16(rate)
@@ -296,6 +449,7 @@ func (qfd *QoSFlowDescription) addQosFlowRateParam(rate string, rateType uint8) 
 
 func GetQosFlowDescUpdate(pcfQosData, ctxtQosData map[string]*models.QosData) *QosFlowsUpdate {
 	if len(pcfQosData) == 0 {
+		logger.PduSessLog.Infof("[QoS-Update] No PCF QoS data received, nothing to update")
 		return nil
 	}
 
@@ -305,21 +459,29 @@ func GetQosFlowDescUpdate(pcfQosData, ctxtQosData map[string]*models.QosData) *Q
 		del: make(map[string]*models.QosData),
 	}
 
-	// Iterate through pcf qos data to identify find add/mod/del qos flows
+	// Iterate through pcf qos data to identify add/mod/del qos flows
 	for name, pcfQF := range pcfQosData {
-		// if pcfQF is null then rule is deleted
+		// if pcfQF is nil then rule is deleted
 		if pcfQF == nil {
-			update.del[name] = pcfQF // nil
+			logger.PduSessLog.Infof("[QoS-Update] Marking QoS flow '%s' for deletion\n", name)
+			update.del[name] = nil
 			continue
 		}
 
 		// Flows to add
 		if ctxtQF := ctxtQosData[name]; ctxtQF == nil {
+			logger.PduSessLog.Infof("[QoS-Update] Adding new QoS flow '%s'\n", name)
 			update.add[name] = pcfQF
 		} else if GetQosDataChanges(pcfQF, ctxtQF) {
+			logger.PduSessLog.Infof("[QoS-Update] Modifying QoS flow '%s'\n", name)
 			update.mod[name] = pcfQF
+		} else {
+			logger.PduSessLog.Infof("[QoS-Update] QoS flow '%s' unchanged\n", name)
 		}
 	}
+
+	logger.PduSessLog.Infof("[QoS-Update] Summary -> Add: %d, Modify: %d, Delete: %d\n",
+		len(update.add), len(update.mod), len(update.del))
 
 	return &update
 }
@@ -347,7 +509,41 @@ func CommitQosFlowDescUpdate(smCtxtPolData *SmCtxtPolicyData, update *QosFlowsUp
 
 // Compare if any change in QoS Data
 func GetQosDataChanges(qf1, qf2 *models.QosData) bool {
-	// TODO
+	if qf1 == nil || qf2 == nil {
+		return true
+	}
+
+	if qf1.QosId != qf2.QosId ||
+		qf1.Var5qi != qf2.Var5qi ||
+		qf1.MaxbrUl != qf2.MaxbrUl ||
+		qf1.MaxbrDl != qf2.MaxbrDl ||
+		qf1.GbrUl != qf2.GbrUl ||
+		qf1.GbrDl != qf2.GbrDl ||
+		qf1.Qnc != qf2.Qnc ||
+		qf1.PriorityLevel != qf2.PriorityLevel ||
+		qf1.AverWindow != qf2.AverWindow ||
+		qf1.MaxDataBurstVol != qf2.MaxDataBurstVol ||
+		qf1.ReflectiveQos != qf2.ReflectiveQos ||
+		qf1.SharingKeyDl != qf2.SharingKeyDl ||
+		qf1.SharingKeyUl != qf2.SharingKeyUl ||
+		qf1.MaxPacketLossRateDl != qf2.MaxPacketLossRateDl ||
+		qf1.MaxPacketLossRateUl != qf2.MaxPacketLossRateUl ||
+		qf1.DefQosFlowIndication != qf2.DefQosFlowIndication {
+		return true
+	}
+
+	// Compare ARP separately
+	if (qf1.Arp == nil) != (qf2.Arp == nil) {
+		return true
+	}
+	if qf1.Arp != nil && qf2.Arp != nil {
+		if qf1.Arp.PriorityLevel != qf2.Arp.PriorityLevel ||
+			qf1.Arp.PreemptCap != qf2.Arp.PreemptCap ||
+			qf1.Arp.PreemptVuln != qf2.Arp.PreemptVuln {
+			return true
+		}
+	}
+
 	return false
 }
 
@@ -393,7 +589,8 @@ func (upd *QosFlowsUpdate) GetAddQosFlowUpdate() map[string]*models.QosData {
 }
 
 func GetDefaultQoSDataFromPolicyDecision(smPolicyDecision *models.SmPolicyDecision) *models.QosData {
-	for _, qosData := range smPolicyDecision.QosDecs {
+	for id, qosData := range smPolicyDecision.QosDecs {
+		logger.QosLog.Infof("QoSData ID=%s, DefQosFlowIndication=%v, 5QI=%d", id, qosData.DefQosFlowIndication, qosData.Var5qi)
 		if qosData.DefQosFlowIndication {
 			return qosData
 		}

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -31,6 +31,11 @@ const (
 	PacketFilterDirectionBidirectional uint8 = 3
 )
 
+const (
+	DefaultDQR = 0 // Default value for Delete QoS Rule flag
+	DefaultQFI = 0 // Default QFI when deleting a QoS Rule
+)
+
 // TS 24.501 Table 9.11.4.13.1
 const (
 	PFComponentTypeMatchAll                       uint8 = 0x01
@@ -163,37 +168,63 @@ func BuildQosRules(smPolicyUpdates *PolicyUpdate) QoSRules {
 	return qosRules
 }
 
+// BuildQosRulespdumod constructs a list of QoS rules for a PDU Session Modification Command
+// based on policy updates (add, modify, delete) from the SM Policy Decision.
+// It returns a slice of QoSRules ready to be encoded in NAS messages.
 func BuildQosRulespdumod(smPolicyUpdates *PolicyUpdate) QoSRules {
 	qosRules := QoSRules{}
 
+	// Extract the SM Policy Decision and PCC Rule updates
 	smPolicyDecision := smPolicyUpdates.SmPolicyDecision
 	pccRulesUpdate := smPolicyUpdates.PccRuleUpdate
 
-	// New Rules to be added
+	// ===============================
+	// Add new QoS rules
+	// ===============================
 	if pccRulesUpdate != nil && pccRulesUpdate.add != nil {
 		for pccRuleName, pccRuleVal := range pccRulesUpdate.add {
 			logger.QosLog.Infof("building QoS Rule from PCC rule [%s]", pccRuleName)
+
+			// Get reference QoS data from SM Policy Decision using the RefQosData index
 			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
+
+			// Build a new QoS rule from the PCC rule and reference QoS data
 			qosRule := BuildAddQoSRuleFromPccRule(pccRuleVal, refQosData, OperationCodeCreateNewQoSRule)
+
+			// Append the constructed rule to the list
 			qosRules = append(qosRules, *qosRule)
 		}
 	}
 
+	// ===============================
+	// Modify existing QoS rules
+	// ===============================
 	if pccRulesUpdate != nil && pccRulesUpdate.mod != nil {
 		for pccRuleName, pccRuleVal := range pccRulesUpdate.mod {
 			logger.QosLog.Infof("building QoS Rule from modified PCC rule [%s]", pccRuleName)
+
+			// Get reference QoS data for modification
 			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
+
+			// Build a QoS rule for modification (OperationCode can be same as create depending on implementation)
 			qosRule := BuildAddQoSRuleFromPccRule(pccRuleVal, refQosData, OperationCodeCreateNewQoSRule)
+
+			// Append modified rule to the list
 			qosRules = append(qosRules, *qosRule)
 		}
 	}
 
-	// Rules to be deleted
+	// ===============================
+	//  Delete QoS rules
+	// ===============================
 	if pccRulesUpdate != nil && pccRulesUpdate.del != nil {
 		for id, pccRuleName := range pccRulesUpdate.del {
 			logger.QosLog.Infof("Processing PCC rule deletion: ID='%s', Name='%s'", id, pccRuleName)
 
+			// Build a delete QoS rule based on the PCC rule ID
 			qosRule := BuildDeleteQosRuleFromPccRule(id)
+
+			// Only append if the rule was successfully created
 			if qosRule != nil {
 				qosRules = append(qosRules, *qosRule)
 
@@ -205,6 +236,7 @@ func BuildQosRulespdumod(smPolicyUpdates *PolicyUpdate) QoSRules {
 				logger.QosLog.Warnf("Skipping QoS rule build for PCC rule ID='%s' (nil returned)", id)
 			}
 		}
+
 		for i, qr := range qosRules {
 			logger.QosLog.Infof("Final QoS Rule[%d] -> Identifier=%d, OperationCode=%d, DQR=%d, QFI=%d",
 				i, qr.Identifier, qr.OperationCode, qr.DQR, qr.QFI)
@@ -213,6 +245,7 @@ func BuildQosRulespdumod(smPolicyUpdates *PolicyUpdate) QoSRules {
 		logger.QosLog.Infof("Total delete QoS Rules built: %d", len(qosRules))
 	}
 
+	// Return the complete list of QoS rules (added, modified, deleted)
 	return qosRules
 }
 
@@ -230,6 +263,8 @@ func BuildAddQoSRuleFromPccRule(pccRule *models.PccRule, qosData *models.QosData
 	return &qRule
 }
 
+// BuildModifyQosRuleFromPccRule constructs a QoSRule modification based on
+// PCC rule updates and QoS data.
 func BuildModifyQosRuleFromPccRule(pccRule *models.PccRule, qosData *models.QosData, pccRuleOpCode uint8) *QosRule {
 	qRule := QosRule{
 		Identifier:    GetQosRuleIdFromPccRuleId(pccRule.PccRuleId),
@@ -252,6 +287,9 @@ func BuildModifyQosRuleFromPccRule(pccRule *models.PccRule, qosData *models.QosD
 	return &qRule
 }
 
+// BuildDeleteQosRuleFromPccRule constructs a QoSRule deletion request for a given PCC rule.
+// This is used when the PCC rule is removed and the corresponding QoS rule
+// needs to be deleted.
 func BuildDeleteQosRuleFromPccRule(pccRuleId string) *QosRule {
 	if pccRuleId == "" {
 		logger.QosLog.Warnf("BuildDeleteQosRuleFromPccRule: empty PCC rule ID, skipping")
@@ -262,8 +300,8 @@ func BuildDeleteQosRuleFromPccRule(pccRuleId string) *QosRule {
 	qRule := QosRule{
 		Identifier:    qosRuleID,
 		OperationCode: OperationCodeDeleteExistingQoSRule,
-		DQR:           0,
-		QFI:           0,
+		DQR:           DefaultDQR,
+		QFI:           DefaultQFI,
 	}
 
 	return &qRule

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -266,15 +266,6 @@ func BuildDeleteQosRuleFromPccRule(pccRuleId string) *QosRule {
 		QFI:           0,
 	}
 
-	logger.QosLog.Infof(
-		"BuildDeleteQosRuleFromPccRule: PCC rule ID='%s' mapped to QoS Rule ID=%d (Delete Operation)",
-		pccRuleId, qosRuleID,
-	)
-	logger.QosLog.Infof(
-		"QoS Rule details - Identifier=%d, OperationCode=%d, DQR=%d, Precedence=%d, QFI=%d",
-		qRule.Identifier, qRule.OperationCode, qRule.DQR, qRule.Precedence, qRule.QFI,
-	)
-
 	return &qRule
 }
 
@@ -287,16 +278,11 @@ func btou(b bool) uint8 {
 
 func GetQosRuleIdFromPccRuleId(pccRuleId string) uint8 {
 	if id, err := strconv.Atoi(pccRuleId); err != nil {
-		// TODO: Error Log
 		return 0
 	} else {
 		return uint8(id)
 	}
 }
-
-/*func GetQosRuleIdFromPccRuleIdpdumod(pccRuleId string) uint8 {
-	return 2
-} */
 
 func (q *QosRule) BuildPacketFilterListFromPccRule(pccRule *models.PccRule) {
 	pfList := []PacketFilter{}
@@ -697,17 +683,6 @@ func (r *QosRule) MarshalBinary() ([]byte, error) {
 		ruleContentBuffer.WriteByte(segregationAndQFIByte)
 	}
 
-	// write precedence
-	/*	if err := ruleContentBuffer.WriteByte(r.Precedence); err != nil {
-			return nil, err
-		}
-
-		// write Segregation and QFI
-		segregationAndQFIByte := r.Segregation<<6 | r.QFI
-		if err := ruleContentBuffer.WriteByte(segregationAndQFIByte); err != nil {
-			return nil, err
-		}*/
-
 	ruleBuffer := bytes.NewBuffer(nil)
 	// write QoS rule identifier
 	if err := ruleBuffer.WriteByte(r.Identifier); err != nil {
@@ -730,10 +705,7 @@ type QoSRules []QosRule
 
 func (rs QoSRules) MarshalBinary() (data []byte, err error) {
 	qosRulesBuffer := bytes.NewBuffer(nil)
-	logger.QosLog.Infof("Starting MarshalBinary for %d QoS rules", len(rs))
-	for i, rule := range rs {
-		logger.QosLog.Infof("Encoding QoS Rule #%d (ID=%d, OpCode=%d, DQR=%d, QFI=%d, PFCount=%d)",
-			i, rule.Identifier, rule.OperationCode, rule.DQR, rule.QFI, len(rule.PacketFilterList))
+	for _, rule := range rs {
 		var ruleBytes []byte
 		if retRuleBytes, err := rule.MarshalBinary(); err != nil {
 			return nil, err
@@ -745,6 +717,5 @@ func (rs QoSRules) MarshalBinary() (data []byte, err error) {
 			return nil, err
 		}
 	}
-	logger.QosLog.Infof("Finished MarshalBinary: total size=%d, hex=%x", len(qosRulesBuffer.Bytes()), qosRulesBuffer.Bytes())
 	return qosRulesBuffer.Bytes(), nil
 }

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -7,6 +7,7 @@ package qos
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -130,7 +131,7 @@ func BuildQosRules(smPolicyUpdates *PolicyUpdate) QoSRules {
 	pccRulesUpdate := smPolicyUpdates.PccRuleUpdate
 
 	// New Rules to be added
-	if pccRulesUpdate != nil {
+	if pccRulesUpdate != nil && pccRulesUpdate.add != nil {
 		for pccRuleName, pccRuleVal := range pccRulesUpdate.add {
 			logger.QosLog.Infof("building QoS Rule from PCC rule [%s]", pccRuleName)
 			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
@@ -139,19 +140,79 @@ func BuildQosRules(smPolicyUpdates *PolicyUpdate) QoSRules {
 		}
 	}
 
-	//Add default Matchall QosRule as well
-	/*
-		if smPolicyUpdates.SessRuleUpdate != nil {
-			defQosRule := BuildAddDefaultQosRule(uint8(smPolicyUpdates.SessRuleUpdate.ActiveSessRule.AuthDefQos.Var5qi))
-			qosRules = append(qosRules, *defQosRule)
+	if pccRulesUpdate != nil && pccRulesUpdate.mod != nil {
+		for pccRuleName, pccRuleVal := range pccRulesUpdate.mod {
+			logger.QosLog.Infof("building QoS Rule from modified PCC rule [%s]", pccRuleName)
+			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
+			qosRule := BuildAddQoSRuleFromPccRule(pccRuleVal, refQosData, OperationCodeCreateNewQoSRule)
+			qosRules = append(qosRules, *qosRule)
 		}
-	*/
-
-	// Rules to be modified
-	// TODO
+	}
 
 	// Rules to be deleted
-	// TODO
+	if pccRulesUpdate != nil && pccRulesUpdate.del != nil {
+		for id, pccRuleName := range pccRulesUpdate.del {
+			logger.QosLog.Infof("building delete QoS Rule for PCC rule [%s]", pccRuleName)
+
+			qosRule := BuildDeleteQosRuleFromPccRule(id)
+			if qosRule != nil {
+				qosRules = append(qosRules, *qosRule)
+			}
+		}
+	}
+	return qosRules
+}
+
+func BuildQosRulespdumod(smPolicyUpdates *PolicyUpdate) QoSRules {
+	qosRules := QoSRules{}
+
+	smPolicyDecision := smPolicyUpdates.SmPolicyDecision
+	pccRulesUpdate := smPolicyUpdates.PccRuleUpdate
+
+	// New Rules to be added
+	if pccRulesUpdate != nil && pccRulesUpdate.add != nil {
+		for pccRuleName, pccRuleVal := range pccRulesUpdate.add {
+			logger.QosLog.Infof("building QoS Rule from PCC rule [%s]", pccRuleName)
+			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
+			qosRule := BuildAddQoSRuleFromPccRule(pccRuleVal, refQosData, OperationCodeCreateNewQoSRule)
+			qosRules = append(qosRules, *qosRule)
+		}
+	}
+
+	if pccRulesUpdate != nil && pccRulesUpdate.mod != nil {
+		for pccRuleName, pccRuleVal := range pccRulesUpdate.mod {
+			logger.QosLog.Infof("building QoS Rule from modified PCC rule [%s]", pccRuleName)
+			refQosData := GetQoSDataFromPolicyDecision(smPolicyDecision, pccRuleVal.RefQosData[0])
+			qosRule := BuildAddQoSRuleFromPccRule(pccRuleVal, refQosData, OperationCodeCreateNewQoSRule)
+			qosRules = append(qosRules, *qosRule)
+		}
+	}
+
+	// Rules to be deleted
+	if pccRulesUpdate != nil && pccRulesUpdate.del != nil {
+		for id, pccRuleName := range pccRulesUpdate.del {
+			logger.QosLog.Infof("Processing PCC rule deletion: ID='%s', Name='%s'", id, pccRuleName)
+
+			qosRule := BuildDeleteQosRuleFromPccRule(id)
+			if qosRule != nil {
+				qosRules = append(qosRules, *qosRule)
+
+				logger.QosLog.Infof(
+					"Built Delete QoS Rule -> Identifier=%d, OperationCode=%d, DQR=%d, QFI=%d",
+					qosRule.Identifier, qosRule.OperationCode, qosRule.DQR, qosRule.QFI,
+				)
+			} else {
+				logger.QosLog.Warnf("Skipping QoS rule build for PCC rule ID='%s' (nil returned)", id)
+			}
+		}
+		for i, qr := range qosRules {
+			logger.QosLog.Infof("Final QoS Rule[%d] -> Identifier=%d, OperationCode=%d, DQR=%d, QFI=%d",
+				i, qr.Identifier, qr.OperationCode, qr.DQR, qr.QFI)
+		}
+
+		logger.QosLog.Infof("Total delete QoS Rules built: %d", len(qosRules))
+	}
+
 	return qosRules
 }
 
@@ -169,12 +230,52 @@ func BuildAddQoSRuleFromPccRule(pccRule *models.PccRule, qosData *models.QosData
 	return &qRule
 }
 
-func BuildModifyQosRuleFromPccRule(pccRule *models.PccRule) *QosRule {
-	return nil
+func BuildModifyQosRuleFromPccRule(pccRule *models.PccRule, qosData *models.QosData, pccRuleOpCode uint8) *QosRule {
+	qRule := QosRule{
+		Identifier:    GetQosRuleIdFromPccRuleId(pccRule.PccRuleId),
+		DQR:           btou(qosData.DefQosFlowIndication),
+		OperationCode: pccRuleOpCode,
+		Precedence:    uint8(pccRule.Precedence),
+		QFI:           GetQosFlowIdFromQosId(qosData.QosId),
+	}
+
+	// Only build packet filter list if the operation involves packet filter changes
+	switch pccRuleOpCode {
+	case OperationCodeModifyExistingQoSRuleAndAddPacketFilters,
+		OperationCodeModifyExistingQoSRuleAndReplaceAllPacketFilters,
+		OperationCodeModifyExistingQoSRuleAndDeletePacketFilters:
+		qRule.BuildPacketFilterListFromPccRule(pccRule)
+	case OperationCodeModifyExistingQoSRuleWithoutModifyingPacketFilters:
+		// No packet filter changes needed
+	}
+
+	return &qRule
 }
 
-func BuildDeleteQosRuleFromPccRule(pccRule *models.PccRule) *QosRule {
-	return nil
+func BuildDeleteQosRuleFromPccRule(pccRuleId string) *QosRule {
+	if pccRuleId == "" {
+		logger.QosLog.Warnf("BuildDeleteQosRuleFromPccRule: empty PCC rule ID, skipping")
+		return nil
+	}
+
+	qosRuleID := GetQosRuleIdFromPccRuleId(pccRuleId)
+	qRule := QosRule{
+		Identifier:    qosRuleID,
+		OperationCode: OperationCodeDeleteExistingQoSRule,
+		DQR:           0,
+		QFI:           0,
+	}
+
+	logger.QosLog.Infof(
+		"BuildDeleteQosRuleFromPccRule: PCC rule ID='%s' mapped to QoS Rule ID=%d (Delete Operation)",
+		pccRuleId, qosRuleID,
+	)
+	logger.QosLog.Infof(
+		"QoS Rule details - Identifier=%d, OperationCode=%d, DQR=%d, Precedence=%d, QFI=%d",
+		qRule.Identifier, qRule.OperationCode, qRule.DQR, qRule.Precedence, qRule.QFI,
+	)
+
+	return &qRule
 }
 
 func btou(b bool) uint8 {
@@ -193,6 +294,10 @@ func GetQosRuleIdFromPccRuleId(pccRuleId string) uint8 {
 	}
 }
 
+/*func GetQosRuleIdFromPccRuleIdpdumod(pccRuleId string) uint8 {
+	return 2
+} */
+
 func (q *QosRule) BuildPacketFilterListFromPccRule(pccRule *models.PccRule) {
 	pfList := []PacketFilter{}
 
@@ -205,6 +310,7 @@ func (q *QosRule) BuildPacketFilterListFromPccRule(pccRule *models.PccRule) {
 }
 
 func GetPacketFilterFromFlowInfo(flowInfo *models.FlowInformation) PacketFilter {
+	fmt.Printf("PackFiltId received: %v\n", flowInfo.PackFiltId)
 	pf := &PacketFilter{
 		Identifier: GetPfId(flowInfo.PackFiltId),
 		Direction:  GetPfDirectionFromPccFlowInfo(flowInfo.FlowDirection),
@@ -216,13 +322,17 @@ func GetPacketFilterFromFlowInfo(flowInfo *models.FlowInformation) PacketFilter 
 	return *pf
 }
 
-func GetPfId(ids string) uint8 {
-	if id, err := strconv.Atoi(ids); err != nil {
-		// TODO: Error Log
+func GetPfId(pfID string) uint8 {
+	if pfID == "" {
+		fmt.Println("Warning: PackFiltId is empty, defaulting to 0")
 		return 0
-	} else {
-		return (uint8(id) & PacketFilterIdBitmask)
 	}
+	id, err := strconv.Atoi(pfID)
+	if err != nil {
+		fmt.Printf("Error converting PackFiltId [%s] to int: %v. Defaulting to 0\n", pfID, err)
+		return 0
+	}
+	return uint8(id)
 }
 
 // Get Packet Filter Directions
@@ -580,17 +690,23 @@ func (r *QosRule) MarshalBinary() ([]byte, error) {
 	if _, err := ruleContentBuffer.ReadFrom(packetFilterListBuffer); err != nil {
 		return nil, err
 	}
+	if r.OperationCode != OperationCodeDeleteExistingQoSRule {
+		// Only for Create/Modify
+		ruleContentBuffer.WriteByte(r.Precedence)
+		segregationAndQFIByte := r.Segregation<<6 | r.QFI
+		ruleContentBuffer.WriteByte(segregationAndQFIByte)
+	}
 
 	// write precedence
-	if err := ruleContentBuffer.WriteByte(r.Precedence); err != nil {
-		return nil, err
-	}
+	/*	if err := ruleContentBuffer.WriteByte(r.Precedence); err != nil {
+			return nil, err
+		}
 
-	// write Segregation and QFI
-	segregationAndQFIByte := r.Segregation<<6 | r.QFI
-	if err := ruleContentBuffer.WriteByte(segregationAndQFIByte); err != nil {
-		return nil, err
-	}
+		// write Segregation and QFI
+		segregationAndQFIByte := r.Segregation<<6 | r.QFI
+		if err := ruleContentBuffer.WriteByte(segregationAndQFIByte); err != nil {
+			return nil, err
+		}*/
 
 	ruleBuffer := bytes.NewBuffer(nil)
 	// write QoS rule identifier
@@ -614,8 +730,10 @@ type QoSRules []QosRule
 
 func (rs QoSRules) MarshalBinary() (data []byte, err error) {
 	qosRulesBuffer := bytes.NewBuffer(nil)
-
-	for _, rule := range rs {
+	logger.QosLog.Infof("Starting MarshalBinary for %d QoS rules", len(rs))
+	for i, rule := range rs {
+		logger.QosLog.Infof("Encoding QoS Rule #%d (ID=%d, OpCode=%d, DQR=%d, QFI=%d, PFCount=%d)",
+			i, rule.Identifier, rule.OperationCode, rule.DQR, rule.QFI, len(rule.PacketFilterList))
 		var ruleBytes []byte
 		if retRuleBytes, err := rule.MarshalBinary(); err != nil {
 			return nil, err
@@ -627,5 +745,6 @@ func (rs QoSRules) MarshalBinary() (data []byte, err error) {
 			return nil, err
 		}
 	}
+	logger.QosLog.Infof("Finished MarshalBinary: total size=%d, hex=%x", len(qosRulesBuffer.Bytes()), qosRulesBuffer.Bytes())
 	return qosRulesBuffer.Bytes(), nil
 }

--- a/qos/traffic_control_data.go
+++ b/qos/traffic_control_data.go
@@ -25,7 +25,8 @@ func GetTrafficControlUpdate(tcData, ctxtTcData map[string]*models.TrafficContro
 	for name, pcfTc := range tcData {
 		// if pcfRule is nil then it need to be deleted
 		if pcfTc == nil {
-			change.del[name] = pcfTc // nil
+			// change.del[name] = pcfTc // nil
+			change.del[name] = nil
 			continue
 		}
 
@@ -62,8 +63,84 @@ func CommitTrafficControlUpdate(smCtxtPolData *SmCtxtPolicyData, update *Traffic
 }
 
 func GetTCDataChanges(pcfTc, ctxtTc *models.TrafficControlData) bool {
-	// TODO
+	if pcfTc == nil || ctxtTc == nil {
+		return true
+	}
+
+	if pcfTc.TcId != ctxtTc.TcId ||
+		pcfTc.FlowStatus != ctxtTc.FlowStatus ||
+		pcfTc.MuteNotif != ctxtTc.MuteNotif ||
+		pcfTc.TrafficSteeringPolIdDl != ctxtTc.TrafficSteeringPolIdDl ||
+		pcfTc.TrafficSteeringPolIdUl != ctxtTc.TrafficSteeringPolIdUl {
+		return true
+	}
+
+	if !compareRedirectInfo(pcfTc.RedirectInfo, ctxtTc.RedirectInfo) {
+		return true
+	}
+
+	if !compareRouteToLocations(pcfTc.RouteToLocs, ctxtTc.RouteToLocs) {
+		return true
+	}
+
+	if !compareUpPathChgEvent(pcfTc.UpPathChgEvent, ctxtTc.UpPathChgEvent) {
+		return true
+	}
+
 	return false
+}
+
+func compareRedirectInfo(a, b *models.RedirectInformation) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return a.RedirectEnabled == b.RedirectEnabled &&
+		a.RedirectAddressType == b.RedirectAddressType &&
+		a.RedirectServerAddress == b.RedirectServerAddress
+}
+
+func compareRouteToLocations(a, b []models.RouteToLocation) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Dnai != b[i].Dnai ||
+			a[i].RouteProfId != b[i].RouteProfId ||
+			!compareRouteInformation(a[i].RouteInfo, b[i].RouteInfo) {
+			return false
+		}
+	}
+	return true
+}
+
+func compareRouteInformation(a, b *models.RouteInformation) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return a.Ipv4Addr == b.Ipv4Addr &&
+		a.Ipv6Addr == b.Ipv6Addr &&
+		a.PortNumber == b.PortNumber
+}
+
+func compareUpPathChgEvent(a, b *models.UpPathChgEvent) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.NotificationUri == b.NotificationUri &&
+		a.NotifCorreId == b.NotifCorreId &&
+		a.DnaiChgType == b.DnaiChgType
 }
 
 func GetTcDataFromPolicyDecision(smPolicyDecision *models.SmPolicyDecision, refTcData string) *models.TrafficControlData {

--- a/util/qos_convert.go
+++ b/util/qos_convert.go
@@ -35,3 +35,12 @@ func BitRateTokbps(bitrate string) uint64 {
 	}
 	return kbps
 }
+
+func NormalizeBitRate(br string) string {
+	// Example: "128.000000 Kbps" → "128 Kbps"
+	parts := strings.Split(br, ".")
+	if len(parts) > 1 {
+		br = parts[0] + " Kbps"
+	}
+	return strings.TrimSpace(br)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind new feature

**What this PR does / why we need it**:

When an IMS call session is released, SMF should correctly handle the session release request.
SMF must send the required PFCP Session Modification to the UPF and a PDU Session Resource Modify Request with the appropriate QoS rule and flow deletion.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #46

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA
**Special notes for your reviewer**:
