### PR TITLE
Fix: Incorrect 5QI in PDU Resource Modify Request

### DIFF
--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -311,9 +311,10 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	// ----------------------------------------------------
 	// Step 4: Check QoS Policy Decision overrides
 	// ----------------------------------------------------
-	policyDecision := ctx.SmPolicyData.SmCtxtQosData.QosData
+	// policyDecision := ctx.SmPolicyData.SmCtxtQosData.QosData
+	policyDecision := ctx.SmPolicyUpdates[0].SmPolicyDecision
 	if policyDecision != nil {
-		for _, qos := range policyDecision {
+		for _, qos := range policyDecision.QosDecs {
 			ctx.SubPduSessLog.Infof(
 				"QoSId=%s, Var5QI=%d, GBR: UL=%s, DL=%s, MBR: UL=%s, DL=%s",
 				qos.QosId, qos.Var5qi, qos.GbrUl, qos.GbrDl, qos.MaxbrUl, qos.MaxbrDl,

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -311,7 +311,6 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	// ----------------------------------------------------
 	// Step 4: Check QoS Policy Decision overrides
 	// ----------------------------------------------------
-	// policyDecision := ctx.SmPolicyData.SmCtxtQosData.QosData
 	policyDecision := ctx.SmPolicyUpdates[0].SmPolicyDecision
 	if policyDecision != nil {
 		for _, qos := range policyDecision.QosDecs {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix

**What this PR does / why we need it**:

This PR fixes an issue where an incorrect 5QI value was being included in the PDU Resource Modify Request message.
The fix ensures that the correct 5QI corresponding to the established PDU session is used during the PDU modification procedure, maintaining consistency with the session’s QoS parameters.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #56

**Test Report Added?**:
> /kind TESTED

**Test Report**:
NA

**Special notes for your reviewer**:
