### PR TITLE
UE IP Not Reused After Deregistration

### DIFF
--- a/context/ip_allocator.go
+++ b/context/ip_allocator.go
@@ -49,7 +49,7 @@ func maskBits(mask net.IPMask) int {
 func IPAddrWithOffset(ip net.IP, offset int) net.IP {
 	retIP := make(net.IP, len(ip))
 	copy(retIP, ip)
-
+	logger.CtxLog.Debugf("IPAddrWithOffset: Base IP: %s, Offset: %d", ip.String(), offset)
 	var carry int
 	for i := len(retIP) - 1; i >= 0; i-- {
 		if offset == 0 {
@@ -59,10 +59,11 @@ func IPAddrWithOffset(ip net.IP, offset int) net.IP {
 		val := int(retIP[i]) + carry + offset%256
 		retIP[i] = byte(val % 256)
 		carry = val / 256
+		logger.CtxLog.Debugf("IPAddrWithOffset: byte[%d] updated to %d, carry: %d, remaining offset: %d", i, retIP[i], carry, offset/256)
 
 		offset /= 256
 	}
-
+	logger.CtxLog.Infof("IPAddrWithOffset: Resulting IP: %s", retIP.String())
 	return retIP
 }
 
@@ -83,11 +84,13 @@ func (a *IPAllocator) Allocate(imsi string) (net.IP, error) {
 	if a.g.staticIps != nil {
 		staticIps := *a.g.staticIps
 		if ipStr := staticIps[imsi]; ipStr != "" {
+			logger.CtxLog.Infof("IPAllocator: Static IP already reserved for IMSI %s: %s", imsi, net.ParseIP(ipStr).To4().String())
 			return net.ParseIP(ipStr).To4(), nil
 		}
 	}
 
 	if offset, err := a.g.allocate(); err != nil {
+		logger.CtxLog.Errorf("IPAllocator: Failed to allocate IP for IMSI %s: %v", imsi, err)
 		return nil, errors.New("ip allocation failed" + err.Error())
 	} else {
 		smfCountStr := os.Getenv("SMF_COUNT")
@@ -98,10 +101,16 @@ func (a *IPAllocator) Allocate(imsi string) (net.IP, error) {
 		if err != nil {
 			logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
 		}
-		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)+(smfCount-1)*5000)
+		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)) //int64((smfCount-1)*5000 + 1)
+		logger.CtxLog.Infof("IPAllocator: Dynamic IP allocation successful for IMSI %s", imsi)
+		logger.CtxLog.Infof("  Allocated IP: %s", ip.String())
 		logger.CtxLog.Infof("unique id - ip %v", ip)
 		logger.CtxLog.Infof("unique id - offset %v", offset)
 		logger.CtxLog.Infof("unique id - smfCount %v", smfCount)
+		if a.ipNetwork != nil {
+			logger.CtxLog.Infof("  Base network IP: %s", a.ipNetwork.IP.String())
+			logger.CtxLog.Infof("  IP Network Mask: %s", a.ipNetwork.Mask.String())
+		}
 		return ip, nil
 	}
 }
@@ -122,16 +131,23 @@ func (a *IPAllocator) BlockIp(ip net.IP) {
 }
 
 func (a *IPAllocator) Release(imsi string, ip net.IP) {
+	if a == nil || a.g == nil || a.ipNetwork == nil {
+		logger.CtxLog.Errorf("IPAllocator not initialized properly, cannot release IP %s for IMSI %s", ip.String(), imsi)
+	}
+	logger.CtxLog.Debugf("Releasing IP %s for IMSI %s", ip.String(), imsi)
 	// Don't release static IPs
 	if a.g.staticIps != nil {
 		staticIps := *a.g.staticIps
 		if ipStr := staticIps[imsi]; ipStr != "" {
+			logger.CtxLog.Debugf("IPAllocator: Not releasing static IP %s for IMSI %s", ipStr, imsi)
 			return
 		}
 	}
 
 	offset := IPAddrOffset(ip, a.ipNetwork.IP)
+	logger.CtxLog.Debugf("IPAllocator: Calculated offset %d for IP %s", offset, ip.String())
 	a.g.release(int64(offset))
+	logger.CtxLog.Infof("IPAllocator: Released IP %s (offset %d) for IMSI %s", ip.String(), offset, imsi)
 }
 
 type _IDPool struct {
@@ -148,30 +164,58 @@ func newIDPool(minValue int64, maxValue int64) (idPool *_IDPool) {
 	idPool.minValue = minValue
 	idPool.maxValue = maxValue
 	idPool.isUsed = make(map[int64]bool)
-	idPool.index = 1
+	smfCountStr := os.Getenv("SMF_COUNT")
+	if smfCountStr == "" {
+		smfCountStr = "1"
+	}
+	smfCount, err := strconv.Atoi(smfCountStr)
+	if err != nil {
+		logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
+	}
+	idPool.index = int64((smfCount-1)*2500 + 1)
 	return
 }
 
 func (i *_IDPool) allocate() (id int64, err error) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-
+	logger.CtxLog.Debugf("IDPool: Starting ID allocation from index %d to maxValue %d", i.index, i.maxValue)
+	smfCountStr := os.Getenv("SMF_COUNT")
+	if smfCountStr == "" {
+		smfCountStr = "1"
+	}
+	smfCount, err := strconv.Atoi(smfCountStr)
+	if err != nil {
+		logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
+	}
 	for id = i.index; id <= i.maxValue; id++ {
 		if _, exist := i.isUsed[id]; !exist {
 			i.isUsed[id] = true
 			i.index = (id % i.maxValue) + 1
+			if i.index == 1 {
+				i.index = int64((smfCount-1)*2500 + 1)
+			}
+			logger.CtxLog.Infof("IDPool: Allocated ID %d (first loop), next index set to %d", id, i.index)
 			return id, nil
+		} else {
+			logger.CtxLog.Infof("IDPool: ID %d already in use", id)
 		}
 	}
 
-	for id = 1; id < i.index; id++ {
+	logger.CtxLog.Debugf("IDPool: Wrapping around, checking IDs from 1 to %d", i.index-1)
+
+	for id = int64((smfCount-1)*2500 + 1); id <= i.index; id++ {
 		if _, exist := i.isUsed[id]; !exist {
 			i.isUsed[id] = true
 			i.index = id + 1
+			logger.CtxLog.Infof("IDPool: Allocated ID %d (wrap-around), next index set to %d", id, i.index)
 			return id, nil
+		} else {
+			logger.CtxLog.Infof("IDPool: ID %d already in use (wrap-around)", id)
 		}
 	}
 
+	logger.CtxLog.Infof("IDPool: No available value range to allocate ID")
 	return 0, errors.New("no available value range to allocate id")
 }
 

--- a/context/ip_allocator.go
+++ b/context/ip_allocator.go
@@ -101,7 +101,7 @@ func (a *IPAllocator) Allocate(imsi string) (net.IP, error) {
 		if err != nil {
 			logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
 		}
-		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)) //int64((smfCount-1)*5000 + 1)
+		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)) // int64((smfCount-1)*5000 + 1)
 		logger.CtxLog.Infof("IPAllocator: Dynamic IP allocation successful for IMSI %s", imsi)
 		logger.CtxLog.Infof("  Allocated IP: %s", ip.String())
 		logger.CtxLog.Infof("unique id - ip %v", ip)

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -135,6 +135,7 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 		metrics.IncrementSessFailureStats(smf_context.SMF_Self().NfInstanceID, string(svcmsgtypes.CreateSmContext), "out", "failure")
 		return fmt.Errorf("IpAllocError")
 	} else {
+		logger.CtxLog.Infof("PDUSessionSMContextCreate: Allocated IP for SUPI %s: %s (before assigning to PDUAddress)", smContext.Supi, ip.String())
 		smContext.PDUAddress = &smf_context.UeIpAddr{Ip: ip, UpfProvided: false}
 		smContext.SubPduSessLog.Infof("PDUSessionSMContextCreate, IP alloc success IP[%s]",
 			smContext.PDUAddress.Ip.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This issue must be fixed because the inability to reuse UE IP addresses after deregistration leads to unnecessary IP pool exhaustion. By ensuring IPs are properly released back into the pool, network stability, resource optimization, and successful PDU session establishment are maintained.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#58](https://github.com/5GC-DEV/smf-cdac/issues/58)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
NA
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
NA