### PR TITLE
Fix: UPF N3 Interface Nil While Running 10K Subscriber Load Test

### DIFF
--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -455,14 +455,12 @@ func HandlePfcpSessionEstablishmentResponse(msg *udp.Message) {
 			logger.PfcpLog.Errorf("can't find UPF[%s]", nodeID.ResolveNodeIdToIp().String())
 			return
 		}
-		newN3 := []smf_context.UPFInterfaceInfo{
-			{
-				IPv4EndPointAddresses: []net.IP{fteid.IPv4Address},
-			},
-		}
+		logger.PfcpLog.Debugf("Locking and updating UPF N3 interface for supi %s", smContext.Supi)
+		n3Interface := smf_context.UPFInterfaceInfo{}
+		n3Interface.IPv4EndPointAddresses = append(n3Interface.IPv4EndPointAddresses, fteid.IPv4Address)
 		upf.UpfLock.Lock()
-		logger.PfcpLog.Debugf("Locked UPF N3 for supi %s", smContext.Supi)
-		upf.N3Interfaces = newN3
+		upf.N3Interfaces = make([]smf_context.UPFInterfaceInfo, 0)
+		upf.N3Interfaces = append(upf.N3Interfaces, n3Interface)
 		upf.UpfLock.Unlock()
 	}
 

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -461,7 +461,7 @@ func HandlePfcpSessionEstablishmentResponse(msg *udp.Message) {
 			},
 		}
 		upf.UpfLock.Lock()
-		logger.PfcpLog.Infof("Locked UPF N3 for supi %s", smContext.Supi)
+		logger.PfcpLog.Debugf("Locked UPF N3 for supi %s", smContext.Supi)
 		upf.N3Interfaces = newN3
 		upf.UpfLock.Unlock()
 	}

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -455,10 +455,15 @@ func HandlePfcpSessionEstablishmentResponse(msg *udp.Message) {
 			logger.PfcpLog.Errorf("can't find UPF[%s]", nodeID.ResolveNodeIdToIp().String())
 			return
 		}
-		upf.N3Interfaces = make([]smf_context.UPFInterfaceInfo, 0)
-		n3Interface := smf_context.UPFInterfaceInfo{}
-		n3Interface.IPv4EndPointAddresses = append(n3Interface.IPv4EndPointAddresses, fteid.IPv4Address)
-		upf.N3Interfaces = append(upf.N3Interfaces, n3Interface)
+		newN3 := []smf_context.UPFInterfaceInfo{
+			{
+				IPv4EndPointAddresses: []net.IP{fteid.IPv4Address},
+			},
+		}
+		upf.UpfLock.Lock()
+		logger.PfcpLog.Infof("Locked UPF N3 for supi %s", smContext.Supi)
+		upf.N3Interfaces = newN3
+		upf.UpfLock.Unlock()
 	}
 
 	if rsp.NodeID == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:

During a 10K subscriber load test, a few UEs failed due to the UPF N3 interface becoming nil, which resulted in PDU Resource Setup Failure. This issue impacts large-scale subscriber load scenarios. When the UPF N3 interface becomes nil, session establishment fails, affecting network reliability and scalability. Ensuring stable N3 interface handling is critical for high-capacity deployments and load testing.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #60

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA
**Special notes for your reviewer**:
