### PR TITLE
Fix: UPF N3 Interface Nil While Running 10K Subscriber Load Test

### DIFF
--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -66,11 +66,15 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 	// Possible cause: Physical interface connecting to UPF may be down
 	logger.CtxLog.Infof("SUPI[%s], PDUSessionID[%d]: N3Interfaces count: %d",
 		ctx.Supi, ctx.PDUSessionID, len(UpNode.N3Interfaces))
+	UpNode.UpfLock.RLock()
 	if len(UpNode.N3Interfaces) == 0 {
+		UpNode.UpfLock.RUnlock()
 		logger.PduSessLog.Errorf("SUPI[%s], PDUSessionID[%d]: No N3 interface available in UPF", ctx.Supi, ctx.PDUSessionID)
 		return nil, fmt.Errorf("N3Interfaces is empty for UPF: %v", UpNode.N3Interfaces)
 	}
-	if n3IP, err := UpNode.N3Interfaces[0].IP(ctx.SelectedPDUSessionType); err != nil {
+	n3IP, err := UpNode.N3Interfaces[0].IP(ctx.SelectedPDUSessionType)
+	UpNode.UpfLock.RUnlock()
+	if err != nil {
 		logger.PduSessLog.Errorf("SUPI[%s], PDUSessionID[%d]: Failed to get N3 IP for UPF, err: %v",
 			ctx.Supi, ctx.PDUSessionID, err)
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:

During a 10K subscriber load test, a few UEs failed due to the UPF N3 interface becoming nil, which resulted in PDU Resource Setup Failure. This issue impacts large-scale subscriber load scenarios. When the UPF N3 interface becomes nil, session establishment fails, affecting network reliability and scalability. Ensuring stable N3 interface handling is critical for high-capacity deployments and load testing.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #60

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA
**Special notes for your reviewer**:
