### PR TITLE
AMF doesn’t respond to a UE’s “existing PDU session” establishment request when the session context is absent.

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -665,11 +665,11 @@ func (smContextState SMContextState) String() string {
 
 func (smContext *SMContext) GeneratePDUSessionEstablishmentReject(cause string) *httpwrapper.Response {
 	var httpResponse *httpwrapper.Response
-	smContext.SubPduSessLog.Infof("Generating PDU Session Establishment Reject for SUPI[%s] with Cause Key: [%s]", smContext.Supi, cause)
+	smContext.SubPduSessLog.Debugf("Generating PDU Session Establishment Reject for SUPI[%s] with Cause Key: [%s]", smContext.Supi, cause)
 	if buf, err := BuildGSMPDUSessionEstablishmentReject(
 		smContext,
 		errors.ErrorCause[cause]); err != nil {
-		smContext.SubPduSessLog.Infof("Failed to build GSM NAS Reject message: %v", err)
+		smContext.SubPduSessLog.Debugf("Failed to build GSM NAS Reject message: %v", err)
 		httpResponse = &httpwrapper.Response{
 			Header: nil,
 			Status: int(errors.ErrorType[cause].Status),
@@ -681,7 +681,7 @@ func (smContext *SMContext) GeneratePDUSessionEstablishmentReject(cause string) 
 			},
 		}
 	} else {
-		smContext.SubPduSessLog.Infof("Successfully built NAS Reject message (Size: %d bytes). Returning HTTP Status: %d", len(buf), int(errors.ErrorType[cause].Status))
+		smContext.SubPduSessLog.Debugf("Successfully built NAS Reject message (Size: %d bytes). Returning HTTP Status: %d", len(buf), int(errors.ErrorType[cause].Status))
 		httpResponse = &httpwrapper.Response{
 			Header: nil,
 			Status: int(errors.ErrorType[cause].Status),

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -369,11 +369,11 @@ func (smContext *SMContext) ReleaseUeIpAddr() error {
 func (smContext *SMContext) ReleasePduSessionID() error {
 	// Check if a PDU Session ID is currently assigned
 	if smContext.PDUSessionID != 0 {
-		smContext.SubPduSessLog.Infof("[ReleasePduSessionID] Releasing PDU Session ID [%d] for SUPI [%s]", smContext.PDUSessionID, smContext.Supi)
+		smContext.SubPduSessLog.Debugf("[ReleasePduSessionID] Releasing PDU Session ID [%d] for SUPI [%s]", smContext.PDUSessionID, smContext.Supi)
 		// Reset the ID to 0 to indicate it is no longer associated with this context
 		smContext.PDUSessionID = 0
 	} else {
-		smContext.SubPduSessLog.Infof("[ReleasePduSessionID] PDU Session ID is 0 or already released")
+		smContext.SubPduSessLog.Debugf("[ReleasePduSessionID] PDU Session ID is 0 or already released")
 	}
 	return nil
 }

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -366,6 +366,18 @@ func (smContext *SMContext) ReleaseUeIpAddr() error {
 	return nil
 }
 
+func (smContext *SMContext) ReleasePduSessionID() error {
+	// Check if a PDU Session ID is currently assigned
+	if smContext.PDUSessionID != 0 {
+		smContext.SubPduSessLog.Infof("[ReleasePduSessionID] Releasing PDU Session ID [%d] for SUPI [%s]", smContext.PDUSessionID, smContext.Supi)
+		// Reset the ID to 0 to indicate it is no longer associated with this context
+		smContext.PDUSessionID = 0
+	} else {
+		smContext.SubPduSessLog.Infof("[ReleasePduSessionID] PDU Session ID is 0 or already released")
+	}
+	return nil
+}
+
 // *** add unit test ***//
 func (smContext *SMContext) SetCreateData(createData *models.SmContextCreateData) {
 	smContext.Gpsi = createData.Gpsi
@@ -653,10 +665,11 @@ func (smContextState SMContextState) String() string {
 
 func (smContext *SMContext) GeneratePDUSessionEstablishmentReject(cause string) *httpwrapper.Response {
 	var httpResponse *httpwrapper.Response
-
+	smContext.SubPduSessLog.Infof("Generating PDU Session Establishment Reject for SUPI[%s] with Cause Key: [%s]", smContext.Supi, cause)
 	if buf, err := BuildGSMPDUSessionEstablishmentReject(
 		smContext,
 		errors.ErrorCause[cause]); err != nil {
+		smContext.SubPduSessLog.Infof("Failed to build GSM NAS Reject message: %v", err)
 		httpResponse = &httpwrapper.Response{
 			Header: nil,
 			Status: int(errors.ErrorType[cause].Status),
@@ -668,6 +681,7 @@ func (smContext *SMContext) GeneratePDUSessionEstablishmentReject(cause string) 
 			},
 		}
 	} else {
+		smContext.SubPduSessLog.Infof("Successfully built NAS Reject message (Size: %d bytes). Returning HTTP Status: %d", len(buf), int(errors.ErrorType[cause].Status))
 		httpResponse = &httpwrapper.Response{
 			Header: nil,
 			Status: int(errors.ErrorType[cause].Status),

--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -6,6 +6,7 @@
 package producer
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/5GC-DEV/nas-cdac"
@@ -34,9 +35,10 @@ type pfcpParam struct {
 	removeQER []*smf_context.QER
 }
 
-func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmContextResponse, pfcpAction *pfcpAction) error {
+func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmContextResponse, pfcpAction *pfcpAction, pfcpParam *pfcpParam) error {
 	body := txn.Req.(models.UpdateSmContextRequest)
 	smContext := txn.Ctxt.(*context.SMContext)
+	tunnel := smContext.Tunnel
 
 	if body.BinaryDataN1SmMessage != nil {
 		smContext.SubPduSessLog.Debugln("PDUSessionSMContextUpdate, Binary Data N1 SmMessage isn't nil")
@@ -97,6 +99,10 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 					smContext.ChangeState(context.SmStateModify)
 					smContext.SubCtxLog.Debugln("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
 				}
+				err := smContext.ReleasePduSessionID()
+				if err != nil {
+					smContext.SubGsmLog.Infof("release PDU Session ID failed: %s", err)
+				}
 			} else {
 				smContext.SubPduSessLog.Errorf("Invalid PDU Session ID")
 				if buf, err := context.BuildGSMPDUSessionReleaseRejectWithCause(smContext, pduSessIDRelReq, "InvalidPDUSessionIdentity"); err != nil {
@@ -135,6 +141,103 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 				smContext.SubPduSessLog.Debugln("PDUSessionSMContextUpdate, sent SMContext Status Notification successfully")
 			}*/
 			smContext.SubPduSessLog.Debugln("PDUSessionSMContextUpdate, sent SMContext Status Notification successfully")
+		case nas.MsgTypePDUSessionEstablishmentRequest:
+			smContext.SubPduSessLog.Infoln("PDUSessionSMContextUpdate, N1 Msg PDU Session Establishment Request received")
+			if smContext.SMContextState != context.SmStateInActivePending {
+				// Wait till the state becomes SmStateActive again
+				// TODO: implement sleep wait in concurrent architecture
+				smContext.SubPduSessLog.Infof("PDUSessionSMContextUpdate, SMContext State[%v] should be SmStateInActivePending State", smContext.SMContextState.String())
+			}
+
+			smContext := txn.Ctxt.(*smf_context.SMContext)
+
+			pduSessIDRelReq := int32(m.PDUSessionEstablishmentRequest.GetPDUSessionID())
+			smContext.SubPduSessLog.Infof("PDU Session ID in Rel Req: ", pduSessIDRelReq)
+			pduSessIDSmCxt := smContext.PDUSessionID
+			smContext.SubPduSessLog.Infof("PDU Session ID in SM Context: ", pduSessIDSmCxt)
+			if pduSessIDRelReq == pduSessIDSmCxt && pduSessIDSmCxt != 0 {
+				if smContext.SMContextState != context.SmStateActive {
+					// Wait till the state becomes Active again
+					// TODO: implement sleep wait in concurrent architecture
+					smContext.SubPduSessLog.Warnf("PDUSessionSMContextUpdate, SMContext state[%v] should be Active",
+						smContext.SMContextState.String())
+				}
+
+				if smContext.PDUSessionID == 0 {
+					smContext.SubPduSessLog.Infof("Context PDU Session ID is 0. Updating Context to Request ID: %d", pduSessIDRelReq)
+					smContext.PDUSessionID = pduSessIDRelReq
+				}
+
+				smContext.ChangeState(context.SmStateModify)
+				smContext.SubCtxLog.Infof("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				pdrList := []*context.PDR{}
+				farList := []*context.FAR{}
+
+				smContext.PendingUPF = make(context.PendingUPF)
+				for _, dataPath := range tunnel.DataPathPool {
+					if dataPath.Activated {
+						ANUPF := dataPath.FirstDPNode
+						for _, DLPDR := range ANUPF.DownLinkTunnel.PDR {
+							DLPDR.FAR.ApplyAction = context.ApplyAction{Buff: false, Drop: false, Dupl: false, Forw: true, Nocp: false}
+							DLPDR.FAR.ForwardingParameters = &context.ForwardingParameters{
+								DestinationInterface: context.DestinationInterface{
+									InterfaceValue: context.DestinationInterfaceAccess,
+								},
+								NetworkInstance: []byte(smContext.Dnn),
+							}
+
+							DLPDR.State = context.RULE_UPDATE
+							DLPDR.FAR.State = context.RULE_UPDATE
+
+							pdrList = append(pdrList, DLPDR)
+							farList = append(farList, DLPDR.FAR)
+
+							if _, exist := smContext.PendingUPF[ANUPF.GetNodeIP()]; !exist {
+								smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+							}
+						}
+					}
+				}
+
+				pfcpParam.pdrList = append(pfcpParam.pdrList, pdrList...)
+				pfcpParam.farList = append(pfcpParam.farList, farList...)
+
+				pfcpAction.sendPfcpModify = true
+				smContext.ChangeState(context.SmStatePfcpModify)
+				smContext.SubCtxLog.Infof("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				if err := SendPfcpSessionModifyReq(smContext, pfcpParam); err != nil {
+					// PFCP modify failed — revert state and return error
+					smContext.SubCtxLog.Errorf("PFCP session modify error: %v", err)
+					// smContext.ChangeState(prevState)
+					smContext.SubCtxLog.Infof("SMContext[%s-%02d] state reverted to %s after PFCP error",
+						smContext.Supi, smContext.PDUSessionID, smContext.SMContextState.String())
+
+					// Build HTTP error response for the original transaction
+					httpResponse := makePduCtxtModifyErrRsp(smContext, err.Error())
+					txn.Err = err
+					txn.Rsp = httpResponse
+					return err
+				}
+				// Set response and change state to active
+				smContext.ChangeState(smf_context.SmStateActive)
+				smContext.SubCtxLog.Info("PFCP Modify success and N1N2 Msg sent, new state:", smContext.SMContextState.String())
+
+				httpResponse := &httpwrapper.Response{
+					Status: http.StatusCreated,
+					Body:   nil,
+				}
+				txn.Rsp = httpResponse
+
+				return nil
+			} else {
+				if smContext.PDUSessionID == 0 {
+					smContext.SubPduSessLog.Infof("Context PDU Session ID is 0. Updating Context to Request ID: %d", pduSessIDRelReq)
+					smContext.PDUSessionID = pduSessIDRelReq
+				}
+				smContext.SubPduSessLog.Infof("Invalid PDU Session ID")
+				txn.Rsp = smContext.GeneratePDUSessionEstablishmentReject("PDUSessionDoesNotExist")
+				return fmt.Errorf("SnssaiError")
+			}
 		}
 	} else {
 		smContext.SubPduSessLog.Debugln("PDUSessionSMContextUpdate, Binary Data N1 SmMessage is nil")

--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -142,19 +142,19 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 			}*/
 			smContext.SubPduSessLog.Debugln("PDUSessionSMContextUpdate, sent SMContext Status Notification successfully")
 		case nas.MsgTypePDUSessionEstablishmentRequest:
-			smContext.SubPduSessLog.Infoln("PDUSessionSMContextUpdate, N1 Msg PDU Session Establishment Request received")
+			smContext.SubPduSessLog.Debugf("PDUSessionSMContextUpdate, N1 Msg PDU Session Establishment Request received")
 			if smContext.SMContextState != context.SmStateInActivePending {
 				// Wait till the state becomes SmStateActive again
 				// TODO: implement sleep wait in concurrent architecture
-				smContext.SubPduSessLog.Infof("PDUSessionSMContextUpdate, SMContext State[%v] should be SmStateInActivePending State", smContext.SMContextState.String())
+				smContext.SubPduSessLog.Debugf("PDUSessionSMContextUpdate, SMContext State[%v] should be SmStateInActivePending State", smContext.SMContextState.String())
 			}
 
 			smContext := txn.Ctxt.(*smf_context.SMContext)
 
 			pduSessIDRelReq := int32(m.PDUSessionEstablishmentRequest.GetPDUSessionID())
-			smContext.SubPduSessLog.Infof("PDU Session ID in Rel Req: ", pduSessIDRelReq)
+			smContext.SubPduSessLog.Debugf("PDU Session ID in Rel Req: ", pduSessIDRelReq)
 			pduSessIDSmCxt := smContext.PDUSessionID
-			smContext.SubPduSessLog.Infof("PDU Session ID in SM Context: ", pduSessIDSmCxt)
+			smContext.SubPduSessLog.Debugf("PDU Session ID in SM Context: ", pduSessIDSmCxt)
 			if pduSessIDRelReq == pduSessIDSmCxt && pduSessIDSmCxt != 0 {
 				if smContext.SMContextState != context.SmStateActive {
 					// Wait till the state becomes Active again
@@ -164,12 +164,12 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 				}
 
 				if smContext.PDUSessionID == 0 {
-					smContext.SubPduSessLog.Infof("Context PDU Session ID is 0. Updating Context to Request ID: %d", pduSessIDRelReq)
+					smContext.SubPduSessLog.Debugf("Context PDU Session ID is 0. Updating Context to Request ID: %d", pduSessIDRelReq)
 					smContext.PDUSessionID = pduSessIDRelReq
 				}
 
 				smContext.ChangeState(context.SmStateModify)
-				smContext.SubCtxLog.Infof("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				smContext.SubCtxLog.Debugf("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
 				pdrList := []*context.PDR{}
 				farList := []*context.FAR{}
 
@@ -204,12 +204,12 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 
 				pfcpAction.sendPfcpModify = true
 				smContext.ChangeState(context.SmStatePfcpModify)
-				smContext.SubCtxLog.Infof("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
+				smContext.SubCtxLog.Debugf("PDUSessionSMContextUpdate, SMContextState Change State:", smContext.SMContextState.String())
 				if err := SendPfcpSessionModifyReq(smContext, pfcpParam); err != nil {
 					// PFCP modify failed — revert state and return error
 					smContext.SubCtxLog.Errorf("PFCP session modify error: %v", err)
 					// smContext.ChangeState(prevState)
-					smContext.SubCtxLog.Infof("SMContext[%s-%02d] state reverted to %s after PFCP error",
+					smContext.SubCtxLog.Debugf("SMContext[%s-%02d] state reverted to %s after PFCP error",
 						smContext.Supi, smContext.PDUSessionID, smContext.SMContextState.String())
 
 					// Build HTTP error response for the original transaction
@@ -220,7 +220,7 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 				}
 				// Set response and change state to active
 				smContext.ChangeState(smf_context.SmStateActive)
-				smContext.SubCtxLog.Info("PFCP Modify success and N1N2 Msg sent, new state:", smContext.SMContextState.String())
+				smContext.SubCtxLog.Debugf("PFCP Modify success and N1N2 Msg sent, new state:", smContext.SMContextState.String())
 
 				httpResponse := &httpwrapper.Response{
 					Status: http.StatusCreated,
@@ -234,9 +234,9 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 					smContext.SubPduSessLog.Infof("Context PDU Session ID is 0. Updating Context to Request ID: %d", pduSessIDRelReq)
 					smContext.PDUSessionID = pduSessIDRelReq
 				}
-				smContext.SubPduSessLog.Infof("Invalid PDU Session ID")
+				smContext.SubPduSessLog.Debugf("Invalid PDU Session ID")
 				txn.Rsp = smContext.GeneratePDUSessionEstablishmentReject("PDUSessionDoesNotExist")
-				return fmt.Errorf("SnssaiError")
+				return fmt.Errorf("PDUSessionDoesNotExist")
 			}
 		}
 	} else {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -353,16 +353,16 @@ func HandlePDUSessionSMContextUpdate(eventData interface{}) error {
 	var response models.UpdateSmContextResponse
 	response.JsonData = new(models.SmContextUpdatedData)
 
-	// N1 Msg Handling
-	if err := HandleUpdateN1Msg(txn, &response, pfcpAction); err != nil {
-		return err
-	}
-
 	pfcpParam := &pfcpParam{
 		pdrList: []*smf_context.PDR{},
 		farList: []*smf_context.FAR{},
 		barList: []*smf_context.BAR{},
 		qerList: []*smf_context.QER{},
+	}
+
+	// N1 Msg Handling
+	if err := HandleUpdateN1Msg(txn, &response, pfcpAction, pfcpParam); err != nil {
+		return err
 	}
 
 	// UP Cnx State handling

--- a/smferrors/errors.go
+++ b/smferrors/errors.go
@@ -109,6 +109,13 @@ var (
 		Cause:         "REQUEST_REJECTED",
 		InvalidParams: nil,
 	}
+	PDUSessionDoesNotExist = models.ProblemDetails{
+		Title:         "PduSession Does Not Exist",
+		Status:        http.StatusNotFound,
+		Detail:        "PDU Session Establishment Request Rejected as PDU Session Does Not Exist .",
+		Cause:         "REQUEST_REJECTED",
+		InvalidParams: nil,
+	}
 )
 
 var ErrorType = map[string]*models.ProblemDetails{
@@ -125,6 +132,7 @@ var ErrorType = map[string]*models.ProblemDetails{
 	"ApplySMPolicyFailure":          &ApplySMPolicyFailure,
 	"AMFDiscoveryFailure":           &AMFDiscoveryFailure,
 	"PDUSessionTypeIPv4OnlyAllowed": &PduSessionTypeNotSupported,
+	"PDUSessionDoesNotExist":        &PDUSessionDoesNotExist,
 }
 
 var ErrorCause = map[string]uint8{
@@ -142,4 +150,5 @@ var ErrorCause = map[string]uint8{
 	"AMFDiscoveryFailure":           nasMessage.Cause5GSMRequestRejectedUnspecified,
 	"PDUSessionTypeIPv4OnlyAllowed": nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed,
 	"InvalidPDUSessionIdentity":     nasMessage.Cause5GSMInvalidPDUSessionIdentity,
+	"PDUSessionDoesNotExist":        nasMessage.Cause5GSMPDUSessionDoesNotExist,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug fix
> /kind enhancement

**What this PR does / why we need it**:

The UE sent a PDU SESSION ESTABLISHMENT REQUEST message with the Request Type set to “existing PDU session” for a PDU session that does not exist in the SMF context.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#63](https://github.com/5GC-DEV/smf-cdac/issues/63)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
NA 
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
Nil