### PR TITLE
48 Hours longevity SMF crash fix

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -358,6 +358,10 @@ func GetSMContextBySEID(SEID uint64) (smContext *SMContext) {
 }
 
 func (smContext *SMContext) ReleaseUeIpAddr() error {
+	if smContext.PDUAddress == nil {
+		smContext.SubPduSessLog.Errorf("[ReleaseUeIpAddr] PDUAddress is nil, nothing to release")
+		return nil
+	}
 	if ip := smContext.PDUAddress.Ip; ip != nil && !smContext.PDUAddress.UpfProvided {
 		smContext.SubPduSessLog.Infof("Release IP[%s]", smContext.PDUAddress.Ip.String())
 		smContext.DNNInfo.UeIPAllocator.Release(smContext.Supi, ip)

--- a/pdusession/api_individual_sm_context.go
+++ b/pdusession/api_individual_sm_context.go
@@ -136,12 +136,49 @@ func HTTPUpdateSmContext(c *gin.Context) {
 	txn.CtxtKey = smContextRef
 	go txn.StartTxnLifeCycle(fsm.SmfTxnFsmHandle)
 	<-txn.Status
-	HTTPResponse := txn.Rsp.(*httpwrapper.Response)
-	// HTTPResponse := producer.HandlePDUSessionSMContextUpdate(
-	//	smContextRef, req.Body.(models.UpdateSmContextRequest))
+	if txn.Err != nil {
+		logger.PduSessLog.Errorf("UpdateSmContext txn failed: %v", txn.Err)
 
+		problem := models.ProblemDetails{
+			Title:  "SM Context not found",
+			Status: http.StatusNotFound,
+			Detail: txn.Err.Error(),
+		}
+
+		stats.IncrementN11MsgStats(
+			smf_context.SMF_Self().NfInstanceID,
+			string(svcmsgtypes.UpdateSmContext),
+			"Out",
+			http.StatusText(http.StatusNotFound),
+			txn.Err.Error(),
+		)
+
+		c.JSON(http.StatusNotFound, problem)
+		return
+	}
+	if txn.Rsp == nil {
+		logger.PduSessLog.Errorln("UpdateSmContext txn completed with NIL response")
+
+		problem := models.ProblemDetails{
+			Title:  "Internal error",
+			Status: http.StatusInternalServerError,
+			Detail: "Transaction response is nil",
+		}
+
+		c.JSON(http.StatusInternalServerError, problem)
+		return
+	}
+
+	HTTPResponse, ok := txn.Rsp.(*httpwrapper.Response)
+	if !ok {
+		logger.PduSessLog.Errorln("Invalid response type from txn")
+
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "invalid transaction response type",
+		})
+		return
+	}
 	stats.IncrementN11MsgStats(smf_context.SMF_Self().NfInstanceID, string(svcmsgtypes.UpdateSmContext), "Out", http.StatusText(HTTPResponse.Status), "")
-
 	if HTTPResponse.Status < 300 {
 		c.Render(HTTPResponse.Status, openapi.MultipartRelatedRender{Data: HTTPResponse.Body})
 	} else {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -161,7 +161,26 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 	if sessSubData, rsp, err := SubscriberDataManagementClient.
 		SessionManagementSubscriptionDataRetrievalApi.
 		GetSmData(context.Background(), smContext.Supi, smDataParams); err != nil {
-		metrics.IncrementSvcUdmMsgStats(smf_context.SMF_Self().NfInstanceID, string(svcmsgtypes.SmSubscriptionDataRetrieval), "In", http.StatusText(rsp.StatusCode), err.Error())
+		statusText := "NO_RESPONSE"
+		if rsp != nil {
+			statusText = http.StatusText(rsp.StatusCode)
+			logger.PduSessLog.Errorln("PDUSessionSMContextCreate: rsp is not NIL %s", smContext.Supi)
+		}
+		metrics.IncrementSvcUdmMsgStats(
+			smf_context.SMF_Self().NfInstanceID,
+			string(svcmsgtypes.SmSubscriptionDataRetrieval),
+			"In",
+			statusText,
+			err.Error(),
+		)
+		if smContext == nil {
+			logger.PduSessLog.Errorln("PDUSessionSMContextCreate: smContext is NIL")
+			return fmt.Errorf("smContext nil")
+		}
+		if rsp == nil {
+			logger.PduSessLog.Errorln("PDUSessionSMContextCreate: response is NIL")
+			return fmt.Errorf("response nil")
+		}
 		smContext.SubPduSessLog.Errorln("PDUSessionSMContextCreate, get SessionManagementSubscriptionData error: ", err)
 		txn.Rsp = smContext.GeneratePDUSessionEstablishmentReject("SubscriptionDataFetchError")
 		metrics.IncrementSessFailureStats(smf_context.SMF_Self().NfInstanceID, string(svcmsgtypes.CreateSmContext), "out", "failure")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
During a 48-hour longevity test, SMF was crashing due to a nil pointer access while handling SM context update and IP address release.  This PR fixes the nil handling and prevents the SMF from crashing, improving stability for long-running deployments.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #65

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
