### PR TITLE
IP Re-allocate and SmfCount in UEpool Fix

### DIFF
--- a/context/ip_allocator.go
+++ b/context/ip_allocator.go
@@ -179,43 +179,48 @@ func newIDPool(minValue int64, maxValue int64) (idPool *_IDPool) {
 func (i *_IDPool) allocate() (id int64, err error) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	logger.CtxLog.Debugf("IDPool: Starting ID allocation from index %d to maxValue %d", i.index, i.maxValue)
+	logger.CtxLog.Debugf("IDPool ALLOCATE START >>> index=%d min=%d max=%d usedCount=%d", i.index, i.minValue, i.maxValue, len(i.isUsed))
 	smfCountStr := os.Getenv("SMF_COUNT")
 	if smfCountStr == "" {
 		smfCountStr = "1"
 	}
 	smfCount, err := strconv.Atoi(smfCountStr)
+	logger.CtxLog.Debugf("IDPool ALLOCATE START >>> smfCount=%d", smfCount)
 	if err != nil {
 		logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
 	}
 	for id = i.index; id <= i.maxValue; id++ {
+		logger.CtxLog.Debugf("IDPool LOOP >>> trying id=%d (index=%d max=%d)", id, i.index, i.maxValue)
 		if _, exist := i.isUsed[id]; !exist {
+			logger.CtxLog.Debugf("IDPool LOOP >>> id=%d already in use, continue", id)
 			i.isUsed[id] = true
 			i.index = (id % i.maxValue) + 1
 			if i.index == 1 {
 				i.index = int64((smfCount-1)*2500 + 1)
 			}
-			logger.CtxLog.Infof("IDPool: Allocated ID %d (first loop), next index set to %d", id, i.index)
 			return id, nil
 		} else {
-			logger.CtxLog.Infof("IDPool: ID %d already in use", id)
+			logger.CtxLog.Debugf("IDPool: ID %d already in use", id)
 		}
 	}
 
-	logger.CtxLog.Debugf("IDPool: Wrapping around, checking IDs from 1 to %d", i.index-1)
-
-	for id = int64((smfCount-1)*2500 + 1); id <= i.index; id++ {
-		if _, exist := i.isUsed[id]; !exist {
-			i.isUsed[id] = true
-			i.index = id + 1
-			logger.CtxLog.Infof("IDPool: Allocated ID %d (wrap-around), next index set to %d", id, i.index)
-			return id, nil
-		} else {
-			logger.CtxLog.Infof("IDPool: ID %d already in use (wrap-around)", id)
+	logger.CtxLog.Debugf("IDPool WRAP >>> index reset from %d to minValue=%d", i.index, i.minValue)
+	id_init := int64((smfCount-1)*2500 + 1)
+	if id_init <= i.maxValue {
+		for id = id_init; id <= i.index; id++ {
+			logger.CtxLog.Debugf("IDPool WRAP LOOP >>> trying id=%d", id)
+			if _, exist := i.isUsed[id]; !exist {
+				i.isUsed[id] = true
+				i.index = id + 1
+				logger.CtxLog.Debugf("IDPool: Allocated ID %d (wrap-around), next index set to %d", id, i.index)
+				return id, nil
+			} else {
+				logger.CtxLog.Debugf("IDPool: ID %d already in use (wrap-around)", id)
+			}
 		}
 	}
-
-	logger.CtxLog.Infof("IDPool: No available value range to allocate ID")
+	logger.CtxLog.Errorln("IDPool EXHAUSTED >>> no free IDs (used=%d maxValue=%d)", len(i.isUsed), i.maxValue)
+	logger.CtxLog.Errorln("IDPool: No available value range to allocate ID")
 	return 0, errors.New("no available value range to allocate id")
 }
 

--- a/service/init.go
+++ b/service/init.go
@@ -325,21 +325,19 @@ func (smf *SMF) Start() {
 		os.Exit(0)
 	}()
 
-	// SetupSmfCollection->moves here
-	// Setup DB first (if enabled)
-	if factory.SmfConfig.Configuration.EnableDbStore {
-		logger.InitLog.Infoln("SetupSmfCollection")
-		context.SetupSmfCollection()
-	}
-
 	// Init SMF Context ONCE
 	smfCtxt := context.InitSmfContext(&factory.SmfConfig)
 
-	// Init DRSM only if DB enabled
+	// Setup SMF Collection
 	if factory.SmfConfig.Configuration.EnableDbStore {
+		logger.InitLog.Infoln("SetupSmfCollection")
+		context.SetupSmfCollection()
+		// Init DRSM for unique FSEID/FTEID/IP-Addr
 		if err := smfCtxt.InitDrsm(); err != nil {
 			logger.InitLog.Errorf("initialise drsm failed, %v ", err.Error())
 		}
+	} else {
+		logger.InitLog.Infoln("DB is disabled, not initialising drsm")
 	}
 
 	// allocate id for each upf

--- a/service/init.go
+++ b/service/init.go
@@ -325,8 +325,22 @@ func (smf *SMF) Start() {
 		os.Exit(0)
 	}()
 
-	// Init SMF Service
+	// SetupSmfCollection->moves here
+	// Setup DB first (if enabled)
+	if factory.SmfConfig.Configuration.EnableDbStore {
+		logger.InitLog.Infoln("SetupSmfCollection")
+		context.SetupSmfCollection()
+	}
+
+	// Init SMF Context ONCE
 	smfCtxt := context.InitSmfContext(&factory.SmfConfig)
+
+	// Init DRSM only if DB enabled
+	if factory.SmfConfig.Configuration.EnableDbStore {
+		if err := smfCtxt.InitDrsm(); err != nil {
+			logger.InitLog.Errorf("initialise drsm failed, %v ", err.Error())
+		}
+	}
 
 	// allocate id for each upf
 	context.AllocateUPFID()
@@ -382,16 +396,7 @@ func (smf *SMF) Start() {
 		}
 	}
 
-	if factory.SmfConfig.Configuration.EnableDbStore {
-		logger.InitLog.Infoln("SetupSmfCollection")
-		context.SetupSmfCollection()
-		// Init DRSM for unique FSEID/FTEID/IP-Addr
-		if err := smfCtxt.InitDrsm(); err != nil {
-			logger.InitLog.Errorf("initialise drsm failed, %v ", err.Error())
-		}
-	} else {
-		logger.InitLog.Infoln("DB is disabled, not initialising drsm")
-	}
+	// set smf collection -> later
 
 	// Init Kafka stream
 	if err := metrics.InitialiseKafkaStream(factory.SmfConfig.Configuration); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
This PR fixes the UE IP reuse logic after deregistration by ensuring that released IP addresses are reused within the configured UE subnet range. It corrects IP pool index handling so that reused IP offsets remain aligned with the subnet boundaries, preventing allocation of invalid IP addresses. This change avoids PDU session establishment failures, prevents out-of-subnet IP assignment, and ensures stable, efficient UE IP management during deregistration and re-registration scenarios.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#67](https://github.com/5GC-DEV/smf-cdac/issues/67)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
NA

**Special notes for your reviewer**:
Nil