### PR TITLE
Fix: Multiple PDU Session Resource Modify Requests Sent to the Same UE 

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -313,24 +313,40 @@ func GetSMContext(ref string) (smContext *SMContext) {
 
 func GetSMContextsByDnnAndImsi(dnn string, imsi string) []*SMContext {
 	var result []*SMContext
-
+	seen := make(map[int32]bool)
 	all := GetAllSMContexts()
 
 	for _, sm := range all {
 		if sm == nil {
+			logger.PduSessLog.Warnf("Encountered nil SMContext, skipping")
 			continue
 		}
 
+		logger.PduSessLog.Debugf("Checking SMContext: Supi=%s Dnn=%s PduSessionId=%d",
+			sm.Supi, sm.Dnn, sm.PDUSessionID)
+
 		// Filter by DNN
 		if sm.Dnn != dnn {
+			logger.PduSessLog.Debugf("DNN mismatch. Expected=%s Found=%s", dnn, sm.Dnn)
 			continue
 		}
 
 		// Optional filter by IMSI/SUPI
 		if imsi != "" && sm.Supi != imsi {
+			logger.PduSessLog.Debugf("IMSI mismatch. Expected=%s Found=%s", imsi, sm.Supi)
 			continue
 		}
 
+		// avoid duplicate PDU session
+		if seen[sm.PDUSessionID] {
+			continue
+		}
+
+		logger.PduSessLog.Infof("SMContext matched: Supi=%s Dnn=%s PduSessionId=%d",
+			sm.Supi, sm.Dnn, sm.PDUSessionID)
+
+		seen[sm.PDUSessionID] = true
+		logger.PduSessLog.Debugf("Total matched SMContexts: %d", len(result))
 		result = append(result, sm)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
During VoNR call establishment, the core should send a single PDU Session Resource Modify Request for the required QoS update. However, multiple requests are being triggered for the same UE and session, which may lead to unnecessary signaling and potential instability during the VoNR procedure.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #71

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
