### PR TITLE
Debug logs added for Longevity: NG_PDU_SESS_RESRC_SETUP_REQ Failure - CreateSmContextRequest Error: server no response

### DIFF
--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -678,7 +678,6 @@ func HandlePfcpSessionDeletionResponse(msg *udp.Message) {
 			SEID,
 			smContext.Supi,
 		)
-
 	} else {
 		if smContext.SMContextState == smf_context.SmStatePfcpRelease &&
 			!smContext.LocalPurged {

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -629,7 +629,6 @@ func HandlePfcpSessionDeletionResponse(msg *udp.Message) {
 
 	if causeValue == ie.CauseRequestAccepted {
 		if smContext.SMContextState == smf_context.SmStatePfcpRelease {
-
 			upfNodeID := smContext.GetNodeIDByLocalSEID(SEID)
 			upfIP := upfNodeID.ResolveNodeIdToIp().String()
 
@@ -658,7 +657,6 @@ func HandlePfcpSessionDeletionResponse(msg *udp.Message) {
 			)
 
 			if smContext.PendingUPF.IsEmpty() && !smContext.LocalPurged {
-
 				smContext.SubPfcpLog.Debugf(
 					"[PFCP] Sending SessionReleaseSuccess to channel SEID[%d] UE[%s]",
 					SEID,
@@ -682,10 +680,8 @@ func HandlePfcpSessionDeletionResponse(msg *udp.Message) {
 		)
 
 	} else {
-
 		if smContext.SMContextState == smf_context.SmStatePfcpRelease &&
 			!smContext.LocalPurged {
-
 			smContext.SubPfcpLog.Debugf(
 				"[PFCP] Sending SessionReleaseSuccess on failure path SEID[%d] UE[%s]",
 				SEID,

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -629,21 +629,77 @@ func HandlePfcpSessionDeletionResponse(msg *udp.Message) {
 
 	if causeValue == ie.CauseRequestAccepted {
 		if smContext.SMContextState == smf_context.SmStatePfcpRelease {
+
 			upfNodeID := smContext.GetNodeIDByLocalSEID(SEID)
 			upfIP := upfNodeID.ResolveNodeIdToIp().String()
+
+			smContext.SubPduSessLog.Debugf(
+				"[PFCP] Before delete pending UPF count[%d] SEID[%d] UE[%s]",
+				len(smContext.PendingUPF),
+				SEID,
+				smContext.Supi,
+			)
+
 			delete(smContext.PendingUPF, upfIP)
-			smContext.SubPduSessLog.Debugf("delete pending pfcp response: UPF IP [%s]", upfIP)
+
+			smContext.SubPduSessLog.Debugf(
+				"[PFCP] After delete pending UPF count[%d] Empty[%t] SEID[%d] UE[%s]",
+				len(smContext.PendingUPF),
+				smContext.PendingUPF.IsEmpty(),
+				SEID,
+				smContext.Supi,
+			)
+
+			smContext.SubPfcpLog.Debugf(
+				"[PFCP] LocalPurged[%v] SEID[%d] UE[%s]",
+				smContext.LocalPurged,
+				SEID,
+				smContext.Supi,
+			)
 
 			if smContext.PendingUPF.IsEmpty() && !smContext.LocalPurged {
+
+				smContext.SubPfcpLog.Debugf(
+					"[PFCP] Sending SessionReleaseSuccess to channel SEID[%d] UE[%s]",
+					SEID,
+					smContext.Supi,
+				)
+
 				smContext.SBIPFCPCommunicationChan <- smf_context.SessionReleaseSuccess
+
+				smContext.SubPfcpLog.Debugf(
+					"[PFCP] SessionReleaseSuccess sent successfully SEID[%d] UE[%s]",
+					SEID,
+					smContext.Supi,
+				)
 			}
 		}
-		smContext.SubPfcpLog.Infof("PFCP Session Deletion Success[%d]", SEID)
+
+		smContext.SubPfcpLog.Infof(
+			"[PFCP] Session Deletion Success SEID[%d] UE[%s]",
+			SEID,
+			smContext.Supi,
+		)
+
 	} else {
-		if smContext.SMContextState == smf_context.SmStatePfcpRelease && !smContext.LocalPurged {
+
+		if smContext.SMContextState == smf_context.SmStatePfcpRelease &&
+			!smContext.LocalPurged {
+
+			smContext.SubPfcpLog.Debugf(
+				"[PFCP] Sending SessionReleaseSuccess on failure path SEID[%d] UE[%s]",
+				SEID,
+				smContext.Supi,
+			)
+
 			smContext.SBIPFCPCommunicationChan <- smf_context.SessionReleaseSuccess
 		}
-		smContext.SubPfcpLog.Infof("PFCP Session Deletion Failed[%d]", SEID)
+
+		smContext.SubPfcpLog.Infof(
+			"[PFCP] Session Deletion Failed SEID[%d] UE[%s]",
+			SEID,
+			smContext.Supi,
+		)
 	}
 }
 

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -44,27 +44,35 @@ func formContextCreateErrRsp(httpStatus int, problemBody *models.ProblemDetails,
 }
 
 func HandlePduSessionContextReplacement(smCtxtRef string) error {
+	logger.PduSessLog.Debugf("HandlePduSessionContextReplacement: ENTER ref=%s", smCtxtRef)
 	smCtxt := smf_context.GetSMContext(smCtxtRef)
 
 	if smCtxt != nil {
 		smCtxt.SubPduSessLog.Warn("PDUSessionSMContextCreate, old context exist, purging")
+		smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: BEFORE_LOCK ref=%s", smCtxtRef)
 		smCtxt.SMLock.Lock()
-
+		smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: LOCK_ACQUIRED ref=%s", smCtxtRef)
 		smCtxt.LocalPurged = true
 
 		// Disassociate ctxt from any look-ups(Report-Req from UPF shouldn't get this context)
 		smf_context.RemoveSMContext(smCtxt.Ref)
-
+		smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: CONTEXT_REMOVED ref=%s", smCtxtRef)
 		smCtxt.PublishSmCtxtInfo()
+		smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: PUBLISHED ref=%s", smCtxtRef)
 		// check if PCF session set, send release(Npcf_SMPolicyControl_Delete)
 		// TODO: not done as part of ctxt release
 
 		// Check if UPF session set, send release
 		if smCtxt.Tunnel != nil {
+			smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: BEFORE_TUNNEL_RELEASE ref=%s", smCtxtRef)
 			releaseTunnel(smCtxt)
+			smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: TUNNEL_RELEASED ref=%s", smCtxtRef)
+		} else {
+			smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: NO_TUNNEL ref=%s", smCtxtRef)
 		}
 
 		smCtxt.SMLock.Unlock()
+		smCtxt.SubPduSessLog.Debugf("HandlePduSessionContextReplacement: EXIT ref=%s", smCtxtRef)
 	}
 
 	return nil
@@ -595,7 +603,21 @@ func HandlePDUSessionSMContextRelease(eventData interface{}) error {
 		return nil
 	}
 
+	smContext.SubCtxLog.Debugf(
+		"[PFCP] Waiting for release response on channel Supi[%s] PduSessID[%d] State[%s]",
+		smContext.Supi,
+		smContext.PDUSessionID,
+		smContext.SMContextState,
+	)
+
 	PFCPResponseStatus := <-smContext.SBIPFCPCommunicationChan
+
+	smContext.SubCtxLog.Debugf(
+		"[PFCP] Channel event received Supi[%s] PduSessID[%d] Event[%+v]",
+		smContext.Supi,
+		smContext.PDUSessionID,
+		PFCPResponseStatus,
+	)
 
 	switch PFCPResponseStatus {
 	case smf_context.SessionReleaseSuccess:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind enhancement

**What this PR does / why we need it**:
This PR adds additional debug logs in the SMF PFCP release handling, and channel event handling to analyze the longevity issue observed during NG_PDU_SESS_RESRC_SETUP_REQ failure scenarios.


**Test Report Added?**:

> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
